### PR TITLE
allow multiple filenames for file

### DIFF
--- a/objects/file/definition.json
+++ b/objects/file/definition.json
@@ -111,6 +111,7 @@
     },
     "filename": {
       "description": "Filename on disk",
+      "multiple": true,
       "categories": [
         "Payload delivery",
         "Artifacts dropped",
@@ -145,7 +146,7 @@
       ]
     }
   },
-  "version": 4,
+  "version": 5,
   "description": "File object describing a file with meta-information",
   "meta-category": "file",
   "uuid": "688c46fb-5edb-40a3-8273-1af7923e2215",


### PR DESCRIPTION
If hashes are equal one can add a new filename to the existing file object instead instead of upload the file multiple times to an event.