### PR TITLE
whois - adds nameserver attributes

### DIFF
--- a/objects/whois/definition.json
+++ b/objects/whois/definition.json
@@ -12,6 +12,7 @@
   "attributes": {
     "text": {
       "description": "Full whois entry",
+      "disable_correlation": true,
       "ui-priority": 1,
       "misp-attribute": "text"
     },
@@ -42,18 +43,29 @@
     },
     "creation-date": {
       "description": "Initial creation of the whois entry",
+      "disable_correlation": true,
       "ui-priority": 0,
       "misp-attribute": "datetime"
     },
     "modification-date": {
       "description": "Last update of the whois entry",
+      "disable_correlation": true,
       "ui-priority": 0,
       "misp-attribute": "datetime"
     },
     "expiration-date": {
       "description": "Expiration of the whois entry",
+      "disable_correlation": true,
       "ui-priority": 0,
       "misp-attribute": "datetime"
+    },
+    "nameserver": {
+      "description": "Nameserver",
+      "ui-priority": 0,
+      "misp-attribute": "hostname",
+      "disable_correlation": true,
+      "multiple": true,
+      "to_ids": false
     },
     "domain": {
       "description": "Domain of the whois entry",
@@ -65,7 +77,7 @@
       "misp-attribute": "domain"
     }
   },
-  "version": 6,
+  "version": 7,
   "description": "Whois records information for a domain name.",
   "meta-category": "network",
   "uuid": "429faea1-34ff-47af-8a00-7c62d3be5a6a",


### PR DESCRIPTION
- adding nameserver attributes as a whois response contains those
- improving performance (and correlation-pollution) by removing unnecessary correlations