### PR TITLE
Add email-body to the email object definition

### DIFF
--- a/objects/email/definition.json
+++ b/objects/email/definition.json
@@ -138,6 +138,14 @@
       "categories": [
         "Payload delivery"
       ]
+    },
+    "email-body": {
+      "description": "Body of the email",
+      "misp-attribute": "email-body",
+      "ui-priority": 1,
+      "categories": [
+        "Payload delivery"
+      ]
     }
   },
   "requiredOneOf": [


### PR DESCRIPTION
Hi there!

I'd love to use the `email` object more often. Currently, the absence of a body means I have to create a separate attribute `Payload delivery -> email-body`.

Can we add this field to the object, or is there a technical reason not to?

Cheers,
David