### PR TITLE
Attributes describing "t_to" and "t_from" fields of a transaction

### DIFF
--- a/objects/transaction/definition.json
+++ b/objects/transaction/definition.json
@@ -60,12 +60,42 @@
     "from-funds-code": {
       "description": "Type of funds used to initiate a transaction.",
       "ui-priority": 0,
-      "misp-attribute": "text"
+      "misp-attribute": "text",
+      "disable_correlation": true,
+      "sane_default": [
+        "A Deposit",
+        "C Currency exchange",
+        "D Casino chips",
+        "E Bank draft",
+        "F Money order",
+        "G Traveler’s cheques",
+        "H Life insurance policy",
+        "I Real estate",
+        "J Securities",
+        "K Cash",
+        "O Other",
+        "P Cheque"
+      ]
     },
     "to-funds-code": {
       "description": "Type of funds used to finalize a transaction.",
       "ui-priority": 0,
-      "misp-attribute": "text"
+      "misp-attribute": "text",
+      "disable_correlation": true,
+      "sane_default": [
+        "A Deposit",
+        "C Currency exchange",
+        "D Casino chips",
+        "E Bank draft",
+        "F Money order",
+        "G Traveler’s cheques",
+        "H Life insurance policy",
+        "I Real estate",
+        "J Securities",
+        "K Cash",
+        "O Other",
+        "P Cheque"
+      ]
     },
     "from-country": {
       "description": "Origin country of a transaction.",

--- a/objects/transaction/definition.json
+++ b/objects/transaction/definition.json
@@ -56,6 +56,26 @@
       "description": "Date of posting, if different from date of transaction.",
       "ui-priority": 0,
       "misp-attribute": "datetime"
+    },
+    "from-funds-code": {
+      "description": "Type of funds used to initiate a transaction.",
+      "ui-priority": 0,
+      "misp-attribute": "text"
+    },
+    "to-funds-code": {
+      "description": "Type of funds used to finalize a transaction.",
+      "ui-priority": 0,
+      "misp-attribute": "text"
+    },
+    "from-country": {
+      "description": "Origin country of a transaction.",
+      "ui-priority": 0,
+      "misp-attribute": "text"
+    },
+    "to-country": {
+      "description": "Target country of a transaction.",
+      "ui-priority": 0,
+      "misp-attribute": "text"
     }
   },
   "version": 1,


### PR DESCRIPTION
Eventhough these attributes are not in the transaction level, they are required in "t_from(_my_client)" and "t_to(_my_client)" fields,  which are required in a transaction.
Since "t_to" and "t_from" can be either accounts, persons, or entities, I did not find any better place to add these attributes.
If you have any comment / suggestion, we can discuss about it 