### PR TITLE
x509-add-required-one-of-serial-number

### DIFF
--- a/objects/x509/definition.json
+++ b/objects/x509/definition.json
@@ -2,7 +2,8 @@
   "requiredOneOf": [
     "x509-fingerprint-md5",
     "x509-fingerprint-sha1",
-    "x509-fingerprint-sha256"
+    "x509-fingerprint-sha256",
+    "serial-number"
   ],
   "attributes": {
     "subject": {


### PR DESCRIPTION
Serial number can be used to create a x509 object
PyMISP must be changed too