### PR TITLE
Added target-system

### DIFF
--- a/objects/target-system/definition.json
+++ b/objects/target-system/definition.json
@@ -1,0 +1,39 @@
+{
+  "name": "target-system",
+  "uuid": "3110944f-eca0-4c94-9d61-a84d022228a4",
+  "meta-category": "Targeting data",
+  "description": "Description about an targeted system, this could potentially be a compromissed internal system",
+  "version": 1,
+  "attributes": {
+    "targeted_machine": {
+      "description": "Targeted system",
+      "ui-priority": 1,
+      "misp-attribute": "target-machine",
+      "disable_correlation": true,
+      "categories": [
+        "Targeting data"
+      ]
+    },
+    "targeted_ip_of_system": {
+      "description": "Targeted system IP address",
+      "ui-priority": 1,
+      "misp-attribute": "ip-src",
+      "disable_correlation": true,
+      "categories": [
+        "Network activity"
+      ]
+    },
+    "timestamp_seen": {
+      "description": "Registered date and time",
+      "ui-priority": 1,
+      "misp-attribute": "datetime",
+      "disable_correlation": true,
+      "categories": [
+        "Other"
+      ]
+    }
+  },
+  "requiredOneOf": [
+    "targeted_machine"
+  ]
+}

--- a/objects/target-system/definition.json
+++ b/objects/target-system/definition.json
@@ -1,7 +1,7 @@
 {
   "name": "target-system",
   "uuid": "3110944f-eca0-4c94-9d61-a84d022228a4",
-  "meta-category": "Targeting data",
+  "meta-category": "internal",
   "description": "Description about an targeted system, this could potentially be a compromissed internal system",
   "version": 1,
   "attributes": {


### PR DESCRIPTION
The target-system object is used to describe internal systems that could be related in an incident e.g. a machine that has been infected with malware.

I'm personally using it to describe a security incident and the affected hosts  