### PR TITLE
Whois: allow multiple domains and/or IP addresses per object

### DIFF
--- a/objects/whois/definition.json
+++ b/objects/whois/definition.json
@@ -89,7 +89,7 @@
       "misp-attribute": "ip-src"
     }
   },
-  "version": 9,
+  "version": 10,
   "description": "Whois records information for a domain name or an IP address.",
   "meta-category": "network",
   "uuid": "429faea1-34ff-47af-8a00-7c62d3be5a6a",


### PR DESCRIPTION
e.g., when an event contains multiple phishing domains registered by a single registrant