### PR TITLE
New misp-object for a shortened URL and the redirect URL

### DIFF
--- a/objects/shortened-link/definition.json
+++ b/objects/shortened-link/definition.json
@@ -1,6 +1,6 @@
 {
   "required": [
-    "url",
+    "redirect-url",
     "shortened-url"
   ],
   "attributes": {
@@ -10,7 +10,7 @@
       "ui-priority": 0,
       "misp-attribute": "datetime"
     },
-    "url": {
+    "redirect-url": {
       "description": "Redirected to URL",
       "ui-priority": 1,
       "misp-attribute": "url"
@@ -36,9 +36,9 @@
       "misp-attribute": "text"
     }
   },
-  "version": 1,
+  "version": 2018060501,
   "description": "Shortened link and its redirect target",
   "meta-category": "network",
-  "uuid": "99c2857c-689f-11e8-adc0-fa7ae01bbebc",
+  "uuid": "361c0ae8-68bd-11e8-adc0-fa7ae01bbebc",
   "name": "shortened-link"
 }

--- a/objects/shortened-link/definition.json
+++ b/objects/shortened-link/definition.json
@@ -4,34 +4,11 @@
     "shortened-url"
   ],
   "attributes": {
-    "port": {
-      "description": "Port number",
-      "ui-priority": 0,
-      "misp-attribute": "port",
-      "disable_correlation": true
-    },
-    "scheme": {
-      "description": "Scheme",
-      "sane_default": [
-        "http",
-        "https",
-        "ftp"
-      ],
-      "ui-priority": 0,
-      "misp-attribute": "text",
-      "disable_correlation": true
-    },
     "first-seen": {
-      "description": "First time this URL has been seen",
+      "description": "First time this shortened URL has been seen",
       "disable_correlation": true,
       "ui-priority": 0,
       "misp-attribute": "datetime"
-    },
-    "query_string": {
-      "description": "Query (after path, preceded by '?')",
-      "ui-priority": 0,
-      "misp-attribute": "text",
-      "multiple": true
     },
     "url": {
       "description": "Redirected to URL",
@@ -62,6 +39,6 @@
   "version": 1,
   "description": "Shortened link and its redirect target",
   "meta-category": "network",
-  "uuid": "3ac2857c-689f-11e8-adc0-fa7ae01bbebc",
+  "uuid": "99c2857c-689f-11e8-adc0-fa7ae01bbebc",
   "name": "shortened-link"
 }

--- a/objects/shortened-link/definition.json
+++ b/objects/shortened-link/definition.json
@@ -1,0 +1,67 @@
+{
+  "required": [
+    "url",
+    "shortened-url"
+  ],
+  "attributes": {
+    "port": {
+      "description": "Port number",
+      "ui-priority": 0,
+      "misp-attribute": "port",
+      "disable_correlation": true
+    },
+    "scheme": {
+      "description": "Scheme",
+      "sane_default": [
+        "http",
+        "https",
+        "ftp"
+      ],
+      "ui-priority": 0,
+      "misp-attribute": "text",
+      "disable_correlation": true
+    },
+    "first-seen": {
+      "description": "First time this URL has been seen",
+      "disable_correlation": true,
+      "ui-priority": 0,
+      "misp-attribute": "datetime"
+    },
+    "query_string": {
+      "description": "Query (after path, preceded by '?')",
+      "ui-priority": 0,
+      "misp-attribute": "text",
+      "multiple": true
+    },
+    "url": {
+      "description": "Redirected to URL",
+      "ui-priority": 1,
+      "misp-attribute": "url"
+    },
+    "shortened-url": {
+      "description": "Shortened URL",
+      "ui-priority": 1,
+      "misp-attribute": "url"
+    },
+    "domain": {
+      "description": "Full domain",
+      "ui-priority": 0,
+      "misp-attribute": "domain"
+    },
+    "credential": {
+      "description": "Credential (username, password)",
+      "ui-priority": 0,
+      "misp-attribute": "text"
+    },
+    "text": {
+      "description": "Description and context of the shortened URL ",
+      "ui-priority": 0,
+      "misp-attribute": "text"
+    }
+  },
+  "version": 1,
+  "description": "Shortened link and its redirect target",
+  "meta-category": "network",
+  "uuid": "3ac2857c-689f-11e8-adc0-fa7ae01bbebc",
+  "name": "shortened-link"
+}


### PR DESCRIPTION
This misp-object is helpful to document a short URL (e.g. goo.gl, TinyURL) and the redirected URL observed

The object has two required fields: _redirect-url_ & _shortened-url_ and both are object _url_ based. Other attributes are _first-seen_, _domain_, _credential_ and _text_.