### PR TITLE
Added current-directory to required field

### DIFF
--- a/objects/process/definition.json
+++ b/objects/process/definition.json
@@ -3,7 +3,7 @@
   "uuid": "02aeef94-ac23-455c-addb-731757ceafb5",
   "meta-category": "misc",
   "description": "Object describing a system process.",
-  "version": 3,
+  "version": 4,
   "attributes": {
     "creation-time": {
       "description": "Local date/time at which the process was created.",
@@ -91,6 +91,7 @@
     "name",
     "pid",
     "image",
-    "command-line"
+    "command-line",
+    "current-directory"
   ]
 }


### PR DESCRIPTION
This field will often indicate where a malicious binary is started from, therefore a good candidate for solo use