### PR TITLE
Username is often utilised alongside a credential

### DIFF
--- a/objects/credential/definition.json
+++ b/objects/credential/definition.json
@@ -1,6 +1,7 @@
 {
   "requiredOneOf": [
-    "password"
+    "password",
+    "username"
   ],
   "attributes": {
     "text": {
@@ -67,7 +68,7 @@
       ]
     }
   },
-  "version": 2,
+  "version": 3,
   "description": "Credential describes one or more credential(s) including password(s), api key(s) or decryption key(s).",
   "meta-category": "misc",
   "uuid": "a27e98c9-9b0e-414c-8076-d201e039ca09",


### PR DESCRIPTION
Username can often identify malicious behavior, and is usually part of the credential tuple - it can also be used to highlight common user accounts without password/api key