### PR TITLE
added option "Further Analysis Required" to attribute stage of object course-of-action

### DIFF
--- a/objects/course-of-action/definition.json
+++ b/objects/course-of-action/definition.json
@@ -53,7 +53,8 @@
       "disable_correlation": true,
       "sane_default": [
         "Remedy",
-        "Response"
+        "Response",
+        "Further Analysis Required"
       ]
     },
     "cost": {


### PR DESCRIPTION
# use case
- when a case is under analysis
- can be used as an indicator that further analysis is required on the particular case/ course of action 