### PR TITLE
Fix Missing Required Attributes

### DIFF
--- a/objects/file/definition.json
+++ b/objects/file/definition.json
@@ -14,7 +14,7 @@
     "sha512/256",
     "tlsh",
     "pattern-in-file",
-    "x509-fingerprint-sha1",
+    "certificate",
     "malware-sample",
     "attachment",
     "path",

--- a/objects/mactime-timeline-analysis/definition.json
+++ b/objects/mactime-timeline-analysis/definition.json
@@ -1,7 +1,7 @@
 {
   "requiredOneOf": [
-    "filepath",
-    "file_activity",
+    "file-path",
+    "activityType",
     "datetime"
   ],
   "attributes": {

--- a/objects/original-imported-file/definition.json
+++ b/objects/original-imported-file/definition.json
@@ -1,7 +1,7 @@
 {
   "requiredOneOf": [
     "imported-sample",
-    "type"
+    "format"
   ],
   "attributes": {
     "imported-sample": {

--- a/objects/phishing-kit/definition.json
+++ b/objects/phishing-kit/definition.json
@@ -90,7 +90,6 @@
   "requiredOneOf": [
     "kit-url",
     "reference-link",
-    "kit-name",
-    "kit-hash"
+    "kit-name"
   ]
 }

--- a/objects/python-etvx-event-log/definition.json
+++ b/objects/python-etvx-event-log/definition.json
@@ -1,7 +1,7 @@
 {
   "required": [
     "source",
-    "type",
+    "event-type",
     "name"
   ],
   "attributes": {


### PR DESCRIPTION
This PR updates the definition files of various object types so that the `required` and `requiredOneOf` lists no longer specify attributes that do not exist in the objects.