### PR TITLE
Attribute Fixes

### DIFF
--- a/objects/regripper-system-hive-general-configuration/definition.json
+++ b/objects/regripper-system-hive-general-configuration/definition.json
@@ -77,7 +77,7 @@
     "comment": {
       "description": "Additional comments.",
       "ui-priority": 0,
-      "misp-attribute": "",
+      "misp-attribute": "text",
       "disable_correlation": true
     }
   },

--- a/objects/regripper-system-hive-service-drivers/definition.json
+++ b/objects/regripper-system-hive-service-drivers/definition.json
@@ -86,7 +86,7 @@
     "comment": {
       "description": "Additional comments.",
       "ui-priority": 0,
-      "misp-attribute": "",
+      "misp-attribute": "text",
       "disable_correlation": true
     }
   },


### PR DESCRIPTION
Update the `misp-attribute` to specify a valid value instead of an empty string.