### PR TITLE
Change undefined category to "External analysis"

### DIFF
--- a/objects/sb-signature/definition.json
+++ b/objects/sb-signature/definition.json
@@ -8,7 +8,7 @@
       "description": "Name of Sandbox software",
       "disable_correlation": true,
       "categories": [
-        "Sandbox detection"
+        "External analysis"
       ],
       "ui-priority": 1,
       "misp-attribute": "text"
@@ -16,7 +16,7 @@
     "signature": {
       "description": "Name of detection signature - set the description of the detection signature as a comment",
       "categories": [
-        "Sandbox detection"
+        "External analysis"
       ],
       "ui-priority": 2,
       "misp-attribute": "text",
@@ -41,7 +41,7 @@
       "misp-attribute": "datetime"
     }
   },
-  "version": 1,
+  "version": 2,
   "description": "Sandbox detection signature",
   "meta-category": "misc",
   "uuid": "984c5c39-be7f-4e1e-b034-d3213bac51cb",


### PR DESCRIPTION
The category "Sandbox detection" doesn't exist, which caused a bug. The right category seems to be "External analysis" according to https://www.circl.lu/doc/misp/categories-and-types/.