### PR TITLE
added "type" to "requiredOneOf"

### DIFF
--- a/objects/pe/definition.json
+++ b/objects/pe/definition.json
@@ -119,7 +119,7 @@
       "misp-attribute": "text"
     }
   },
-  "version": 3,
+  "version": 4,
   "description": "Object describing a Portable Executable",
   "meta-category": "file",
   "uuid": "cf7adecc-d4f0-4e88-9d90-f978ee151a07",

--- a/objects/pe/definition.json
+++ b/objects/pe/definition.json
@@ -1,6 +1,7 @@
 {
   "requiredOneOf": [
     "text",
+    "type",
     "original-filename",
     "internal-filename",
     "entrypoint-address"


### PR DESCRIPTION
Sometimes filenames are unknown and entrypoint or text not of interest.
The PE type is most often of interest and can be quickly determined by an analyst.