### PR TITLE
add facebook objects

### DIFF
--- a/objects/facebook-group/definition.json
+++ b/objects/facebook-group/definition.json
@@ -71,12 +71,12 @@
     "privacy": {
       "description": "Group privacy: public, closed, secret.",
       "misp-attribute": "text",
-      "ui-priority": 1,
       "sane_default": [
         "Public",
         "Closed",
         "Secret"
-      ]
+      ],
+      "ui-priority": 1
     },
     "url": {
       "description": "Original URL location of the group (potentially malicious).",

--- a/objects/facebook-group/definition.json
+++ b/objects/facebook-group/definition.json
@@ -1,0 +1,98 @@
+{
+  "attributes": {
+    "administrator": {
+      "description": "A user account who is an owner or admin of the group.",
+      "misp-attribute": "text",
+      "multiple": true,
+      "ui-priority": 1
+    },
+    "archive": {
+      "description": "Archive of the original group (Internet Archive, Archive.is, etc).",
+      "disable_correlation": true,
+      "misp-attribute": "link",
+      "multiple": true,
+      "ui-priority": 1
+    },
+    "attachment": {
+      "description": "A screen capture or exported list of contacts, group members, etc.",
+      "misp-attribute": "attachment",
+      "multiple": true,
+      "ui-priority": 1
+    },
+    "creator": {
+      "description": "The user account that created the group.",
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "description": {
+      "description": "A description of the group, channel or community.",
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "embedded-link": {
+      "description": "Link embedded in the group description (potentially malicious).",
+      "misp-attribute": "url",
+      "multiple": true,
+      "ui-priority": 0
+    },
+    "embedded-safe-link": {
+      "description": "Link embedded in the group description (supposed safe).",
+      "misp-attribute": "link",
+      "multiple": true,
+      "ui-priority": 0
+    },
+    "group-alias": {
+      "description": "Aliases or previous names of group.",
+      "misp-attribute": "text",
+      "multiple": true,
+      "ui-priority": 1
+    },
+    "group-name": {
+      "description": "The name of the group, channel or community.",
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "group-type": {
+      "description": "Facebook group type, e.g. general, buy and sell etc.",
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "hashtag": {
+      "description": "Hashtag used to identify or promote the group.",
+      "misp-attribute": "text",
+      "multiple": true,
+      "ui-priority": 0
+    },
+    "link": {
+      "description": "Original link to the group (supposed harmless).",
+      "misp-attribute": "link",
+      "ui-priority": 1
+    },
+    "privacy": {
+      "description": "Group privacy: public, closed, secret.",
+      "misp-attribute": "text",
+      "ui-priority": 1,
+      "sane_default": [
+        "Public",
+        "Closed",
+        "Secret"
+      ]
+    },
+    "url": {
+      "description": "Original URL location of the group (potentially malicious).",
+      "misp-attribute": "url",
+      "ui-priority": 1
+    }
+  },
+  "description": "Public or private facebook group.",
+  "meta-category": "misc",
+  "name": "facebook-group",
+  "requiredOneOf": [
+    "group-name",
+    "description",
+    "archive",
+    "link"
+  ],
+  "uuid": "165c5507-1cba-4cec-9be4-66e21b590ee6",
+  "version": 1
+}

--- a/objects/facebook-page/definition.json
+++ b/objects/facebook-page/definition.json
@@ -1,16 +1,5 @@
 {
   "attributes": {
-    "team-member": {
-      "description": "A user account who is a member of the page.",
-      "misp-attribute": "text",
-      "multiple": true,
-      "ui-priority": 1
-    },
-    "creator": {
-      "description": "The user account that created the page.",
-      "misp-attribute": "text",
-      "ui-priority": 1
-    },
     "archive": {
       "description": "Archive of the original page (Internet Archive, Archive.is, etc).",
       "disable_correlation": true,
@@ -22,6 +11,17 @@
       "description": "A screen capture or exported list of contacts, page members, etc.",
       "misp-attribute": "attachment",
       "multiple": true,
+      "ui-priority": 1
+    },
+    "contact-detail": {
+      "description": "Contact url listed on about page.",
+      "misp-attribute": "url",
+      "multiple": true,
+      "ui-priority": 1
+    },
+    "creator": {
+      "description": "The user account that created the page.",
+      "misp-attribute": "text",
       "ui-priority": 1
     },
     "description": {
@@ -41,49 +41,10 @@
       "multiple": true,
       "ui-priority": 0
     },
-    "page-name": {
-      "description": "The name of the page.",
-      "misp-attribute": "text",
-      "ui-priority": 1
-    },
-    "page-id": {
-      "description": "Page id (without the @).",
-      "misp-attribute": "text",
-      "ui-priority": 1
-    },
-    "page-alias": {
-      "description": "Aliases or previous names of page.",
-      "misp-attribute": "text",
-      "multiple": true,
-      "ui-priority": 1
-    },
-    "related-page-name": {
-      "description": "name of a page listed as related to this one.",
-      "misp-attribute": "text",
-      "multiple": true,
-      "ui-priority": 1
-    },
-    "related-page-id": {
-      "description": "id of a page listed as related to this one (without the @).",
-      "misp-attribute": "text",
-      "multiple": true,
-      "ui-priority": 1
-    },
     "event": {
       "description": "Event announcement on page.",
       "misp-attribute": "text",
       "multiple": true,
-      "ui-priority": 1
-    },
-    "contact-detail": {
-      "description": "Contact url listed on about page.",
-      "misp-attribute": "url",
-      "multiple": true,
-      "ui-priority": 1
-    },
-    "page-type": {
-      "description": "Facebook page type, e.g. community, product etc.",
-      "misp-attribute": "text",
       "ui-priority": 1
     },
     "hashtag": {
@@ -95,6 +56,45 @@
     "link": {
       "description": "Original link to the page (supposed harmless).",
       "misp-attribute": "link",
+      "ui-priority": 1
+    },
+    "page-alias": {
+      "description": "Aliases or previous names of page.",
+      "misp-attribute": "text",
+      "multiple": true,
+      "ui-priority": 1
+    },
+    "page-id": {
+      "description": "Page id (without the @).",
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "page-name": {
+      "description": "The name of the page.",
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "page-type": {
+      "description": "Facebook page type, e.g. community, product etc.",
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "related-page-id": {
+      "description": "id of a page listed as related to this one (without the @).",
+      "misp-attribute": "text",
+      "multiple": true,
+      "ui-priority": 1
+    },
+    "related-page-name": {
+      "description": "name of a page listed as related to this one.",
+      "misp-attribute": "text",
+      "multiple": true,
+      "ui-priority": 1
+    },
+    "team-member": {
+      "description": "A user account who is a member of the page.",
+      "misp-attribute": "text",
+      "multiple": true,
       "ui-priority": 1
     },
     "url": {

--- a/objects/facebook-page/definition.json
+++ b/objects/facebook-page/definition.json
@@ -1,0 +1,117 @@
+{
+  "attributes": {
+    "team-member": {
+      "description": "A user account who is a member of the page.",
+      "misp-attribute": "text",
+      "multiple": true,
+      "ui-priority": 1
+    },
+    "creator": {
+      "description": "The user account that created the page.",
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "archive": {
+      "description": "Archive of the original page (Internet Archive, Archive.is, etc).",
+      "disable_correlation": true,
+      "misp-attribute": "link",
+      "multiple": true,
+      "ui-priority": 1
+    },
+    "attachment": {
+      "description": "A screen capture or exported list of contacts, page members, etc.",
+      "misp-attribute": "attachment",
+      "multiple": true,
+      "ui-priority": 1
+    },
+    "description": {
+      "description": "A description of the page.",
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "embedded-link": {
+      "description": "Link embedded in the page description (potentially malicious).",
+      "misp-attribute": "url",
+      "multiple": true,
+      "ui-priority": 0
+    },
+    "embedded-safe-link": {
+      "description": "Link embedded in the page description (supposed safe).",
+      "misp-attribute": "link",
+      "multiple": true,
+      "ui-priority": 0
+    },
+    "page-name": {
+      "description": "The name of the page.",
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "page-id": {
+      "description": "Page id (without the @).",
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "page-alias": {
+      "description": "Aliases or previous names of page.",
+      "misp-attribute": "text",
+      "multiple": true,
+      "ui-priority": 1
+    },
+    "related-page-name": {
+      "description": "name of a page listed as related to this one.",
+      "misp-attribute": "text",
+      "multiple": true,
+      "ui-priority": 1
+    },
+    "related-page-id": {
+      "description": "id of a page listed as related to this one (without the @).",
+      "misp-attribute": "text",
+      "multiple": true,
+      "ui-priority": 1
+    },
+    "event": {
+      "description": "Event announcement on page.",
+      "misp-attribute": "text",
+      "multiple": true,
+      "ui-priority": 1
+    },
+    "contact-detail": {
+      "description": "Contact url listed on about page.",
+      "misp-attribute": "url",
+      "multiple": true,
+      "ui-priority": 1
+    },
+    "page-type": {
+      "description": "Facebook page type, e.g. community, product etc.",
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "hashtag": {
+      "description": "Hashtag used to identify or promote the page.",
+      "misp-attribute": "text",
+      "multiple": true,
+      "ui-priority": 0
+    },
+    "link": {
+      "description": "Original link to the page (supposed harmless).",
+      "misp-attribute": "link",
+      "ui-priority": 1
+    },
+    "url": {
+      "description": "Original URL location of the page (potentially malicious).",
+      "misp-attribute": "url",
+      "ui-priority": 1
+    }
+  },
+  "description": "Facebook page.",
+  "meta-category": "misc",
+  "name": "facebook-page",
+  "requiredOneOf": [
+    "page-name",
+    "description",
+    "archive",
+    "link"
+  ],
+  "uuid": "e76892db-c168-4289-b957-56e3021c46b9",
+  "version": 1
+}

--- a/objects/facebook-post/definition.json
+++ b/objects/facebook-post/definition.json
@@ -1,0 +1,125 @@
+{
+  "attributes": {
+    "archive": {
+      "description": "Archive of the original document (Internet Archive, Archive.is, etc).",
+      "misp-attribute": "link",
+      "multiple": true,
+      "ui-priority": 1
+    },
+    "attachment": {
+      "description": "The facebook post file or screen capture.",
+      "misp-attribute": "attachment",
+      "multiple": true,
+      "ui-priority": 1
+    },
+    "user-name": {
+      "description": "Display name of the account who posted.",
+      "misp-attribute": "text",
+      "ui-priority": 0
+    },
+    "user-id": {
+      "description": "Id of the account who posted.",
+      "misp-attribute": "text",
+      "ui-priority": 0
+    },
+    "embedded-link": {
+      "description": "Link in the facebook post",
+      "misp-attribute": "url",
+      "multiple": true,
+      "ui-priority": 0
+    },
+    "embedded-safe-link": {
+      "description": "Safe link in the facebook post",
+      "misp-attribute": "link",
+      "multiple": true,
+      "ui-priority": 0
+    },
+    "hashtag": {
+      "description": "Hashtag embedded in the facebook post",
+      "misp-attribute": "text",
+      "multiple": true,
+      "ui-priority": 0
+    },
+    "in-reply-to-status-id": {
+      "description": "The facebook ID of the post that this post shares.",
+      "misp-attribute": "text",
+      "multiple": true,
+      "ui-priority": 0
+    },
+    "in-reply-to-display-name": {
+      "description": "The user display name of the facebook this post shares.",
+      "misp-attribute": "text",
+      "multiple": true,
+      "ui-priority": 0
+    },
+    "in-reply-to-user-id": {
+      "description": "The user ID of the facebook this post shares.",
+      "misp-attribute": "text",
+      "multiple": true,
+      "ui-priority": 0
+    },
+    "language": {
+      "description": "The language of the post.",
+      "misp-attribute": "text",
+      "disable_correlation": true,
+      "multiple": true,
+      "ui-priority": 0
+    },
+    "link": {
+      "description": "Original link to the facebook post (supposed harmless).",
+      "misp-attribute": "link",
+      "multiple": true,
+      "ui-priority": 1
+    },
+    "post": {
+      "description": "Raw text of the post.",
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "removal-date": {
+      "description": "When the facebook post was removed.",
+      "misp-attribute": "datetime",
+      "ui-priority": 0
+    },
+    "post-location": {
+      "description": "id of the group, page or wall the post was posted to.",
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "post-id": {
+      "description": "The facebook post id.",
+      "misp-attribute": "post-id",
+      "ui-priority": 0
+    },
+    "url": {
+      "description": "Original URL of the facebook post, e.g. link shortener (potentially malicious).",
+      "misp-attribute": "url",
+      "multiple": true,
+      "ui-priority": 1
+    },
+    "username": {
+      "description": "Username who posted the facebook post",
+      "misp-attribute": "text",
+      "ui-priority": 0
+    },
+    "username-quoted": {
+      "description": "Username who is quoted in the facebook post.",
+      "misp-attribute": "text",
+      "multiple": true,
+      "ui-priority": 0
+    }
+  },
+  "description": "Post on a Facebook wall.",
+  "meta-category": "misc",
+  "name": "facebook-post",
+  "requiredOneOf": [
+    "post",
+    "post-id",
+    "archive",
+    "url",
+    "link",
+    "attachment"
+  ],
+  "uuid": "82c1fd90-85a1-4420-a315-d2a7cfae2f01",
+  "version": 1
+}

--- a/objects/facebook-post/definition.json
+++ b/objects/facebook-post/definition.json
@@ -68,7 +68,7 @@
     },
     "post-id": {
       "description": "The facebook post id.",
-      "misp-attribute": "post-id",
+      "misp-attribute": "text",
       "ui-priority": 0
     },
     "post-location": {

--- a/objects/facebook-post/definition.json
+++ b/objects/facebook-post/definition.json
@@ -12,16 +12,6 @@
       "multiple": true,
       "ui-priority": 1
     },
-    "user-name": {
-      "description": "Display name of the account who posted.",
-      "misp-attribute": "text",
-      "ui-priority": 0
-    },
-    "user-id": {
-      "description": "Id of the account who posted.",
-      "misp-attribute": "text",
-      "ui-priority": 0
-    },
     "embedded-link": {
       "description": "Link in the facebook post",
       "misp-attribute": "url",
@@ -40,14 +30,14 @@
       "multiple": true,
       "ui-priority": 0
     },
-    "in-reply-to-status-id": {
-      "description": "The facebook ID of the post that this post shares.",
+    "in-reply-to-display-name": {
+      "description": "The user display name of the facebook this post shares.",
       "misp-attribute": "text",
       "multiple": true,
       "ui-priority": 0
     },
-    "in-reply-to-display-name": {
-      "description": "The user display name of the facebook this post shares.",
+    "in-reply-to-status-id": {
+      "description": "The facebook ID of the post that this post shares.",
       "misp-attribute": "text",
       "multiple": true,
       "ui-priority": 0
@@ -60,8 +50,8 @@
     },
     "language": {
       "description": "The language of the post.",
-      "misp-attribute": "text",
       "disable_correlation": true,
+      "misp-attribute": "text",
       "multiple": true,
       "ui-priority": 0
     },
@@ -76,9 +66,9 @@
       "misp-attribute": "text",
       "ui-priority": 1
     },
-    "removal-date": {
-      "description": "When the facebook post was removed.",
-      "misp-attribute": "datetime",
+    "post-id": {
+      "description": "The facebook post id.",
+      "misp-attribute": "post-id",
       "ui-priority": 0
     },
     "post-location": {
@@ -86,9 +76,9 @@
       "misp-attribute": "text",
       "ui-priority": 1
     },
-    "post-id": {
-      "description": "The facebook post id.",
-      "misp-attribute": "post-id",
+    "removal-date": {
+      "description": "When the facebook post was removed.",
+      "misp-attribute": "datetime",
       "ui-priority": 0
     },
     "url": {
@@ -96,6 +86,16 @@
       "misp-attribute": "url",
       "multiple": true,
       "ui-priority": 1
+    },
+    "user-id": {
+      "description": "Id of the account who posted.",
+      "misp-attribute": "text",
+      "ui-priority": 0
+    },
+    "user-name": {
+      "description": "Display name of the account who posted.",
+      "misp-attribute": "text",
+      "ui-priority": 0
     },
     "username": {
       "description": "Username who posted the facebook post",

--- a/objects/tracking-id/definition.json
+++ b/objects/tracking-id/definition.json
@@ -1,35 +1,36 @@
 {
   "attributes": {
     "description": {
-      "description": "Description of the tracking id",
+      "description": "Description of the tracking id.",
+      "disable_correlation": true,
       "misp-attribute": "text",
       "ui-priority": 1
     },
     "first-seen": {
-      "description": "First time the tracking code was seen",
+      "description": "First time the tracking code was seen.",
       "disable_correlation": true,
       "misp-attribute": "datetime",
       "ui-priority": 0
     },
     "hostname": {
-      "description": "hostname where the tracking id was found",
+      "description": "Hostname where the tracking id was found (assumed safe).",
       "misp-attribute": "hostname",
       "multiple": true,
       "ui-priority": 0
     },
     "id": {
-      "description": "Tracking code",
+      "description": "Tracking code.",
       "misp-attribute": "text",
       "ui-priority": 1
     },
     "last-seen": {
-      "description": "Last time the tracking code was seen",
+      "description": "Last time the tracking code was seen.",
       "disable_correlation": true,
       "misp-attribute": "datetime",
       "ui-priority": 0
     },
     "tracker": {
-      "description": "Name of the tracker - organisation doing the tracking and/or analytics",
+      "description": "Name of the tracker - organisation doing the tracking and/or analytics.",
       "misp-attribute": "text",
       "sane_default": [
         "Google Analytics",
@@ -41,7 +42,7 @@
       "ui-priority": 1
     },
     "url": {
-      "description": "URL where the tracking id was found",
+      "description": "URL where the tracking id was found (potentially malicious).",
       "misp-attribute": "url",
       "multiple": true,
       "ui-priority": 1
@@ -54,5 +55,5 @@
     "id"
   ],
   "uuid": "3681c62a-2c75-48d8-99f2-6a3444ce2393",
-  "version": 2
+  "version": 3
 }


### PR DESCRIPTION
These are some Facebook objects to replace how we're currently using the `microblog` object.  

The plan is to break out each social media platform into a set of objects. We're doing this to make it easier for analysts to recognize the appropriate object type to use, and to prevent objects like `microblog` becoming very large.  Twitter, Reddit, etc. are on the way.

Thanks!