### PR TITLE
chg: [dev] add object properties from #254

### DIFF
--- a/objects/twitter-account/definition.json
+++ b/objects/twitter-account/definition.json
@@ -13,6 +13,31 @@
       "multiple": true,
       "ui-priority": 1
     },
+    "avatar": {
+      "description": "A screenshot or exported user avatar.",
+      "misp-attribute": "attachment",
+      "ui-priority": 1
+    },
+    "avatar-url": {
+      "description": "A link to the user's avatar.",
+      "misp-attribute": "url",
+      "ui-priority": 1
+    },
+    "background-image": {
+      "description": "A screenshot or exported user avatar.",
+      "misp-attribute": "attachment",
+      "ui-priority": 1
+    },
+    "background-image-url": {
+      "description": "A link to the user's background image.",
+      "misp-attribute": "url",
+      "ui-priority": 1
+    },
+    "bio": {
+      "description": "Displayed name.",
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
     "description": {
       "description": "A description of the user.",
       "disable_correlation": true,
@@ -37,13 +62,13 @@
       "ui-priority": 0
     },
     "followers": {
-      "description": "number of followers.",
+      "description": "Number of followers.",
       "disable_correlation": true,
       "misp-attribute": "text",
       "ui-priority": 1
     },
-    "friends": {
-      "description": "Number of friends.",
+    "following": {
+      "description": "Number of accounts this accounts is following.",
       "disable_correlation": true,
       "misp-attribute": "text",
       "ui-priority": 1
@@ -56,6 +81,12 @@
     },
     "id": {
       "description": "Numeric account id.",
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "likes": {
+      "description": "Number of likes this account has.",
+      "disable_correlation": true,
       "misp-attribute": "text",
       "ui-priority": 1
     },
@@ -76,8 +107,29 @@
       "misp-attribute": "text",
       "ui-priority": 1
     },
+    "media": {
+      "description": "Number of images and videos posted.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
     "name": {
       "description": "User's screen name (without the @).",
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "private": {
+      "description": "User verified.",
+      "misp-attribute": "text",
+      "sane_default": [
+        "True",
+        "False"
+      ],
+      "ui-priority": 1
+    },
+    "tweets": {
+      "description": "Number of tweets posted.",
+      "disable_correlation": true,
       "misp-attribute": "text",
       "ui-priority": 1
     },
@@ -107,5 +159,5 @@
     "link"
   ],
   "uuid": "8066563f-881e-4f6a-9d6c-a9d15b8658bb",
-  "version": 1
+  "version": 2
 }


### PR DESCRIPTION
#254

avatar-url == background_image
background-image-url == profile_image_url
name == usernamme

Everything else is there except for `join_date` and `join_time` which I assumed are satisfied by `First seen date` and `First seen time` properties during object creation.  Should those fields be used differently?

{
  "id": 15171302,
  "name": "Alexandre Dulaunoy",
  "username": "adulau",
  "bio": "Enjoy when human are using machines in unexpected ways. \r I break stuff and I do stuff.",
  "location": "Europe",
  "url": "http://www.foo.be/",
  "join_date": "19 Jun 2008",
  "join_time": "10:36 AM",
  "tweets": 11460,
  "following": 5870,
  "followers": 5808,
  "likes": 10081,
  "media": 641,
  "private": 0,
  "verified": 0,
  "profile_image_url": "https://pbs.twimg.com/profile_images/1248503736957165576/AN7SC5SB_400x400.jpg",
  "background_image": "https://pbs.twimg.com/profile_banners/15171302/1509820835/1500x500"
}


