### PR TITLE
Using the actual attribute type for cpe and weakness instead of text

### DIFF
--- a/objects/cpe-asset/definition.json
+++ b/objects/cpe-asset/definition.json
@@ -2,7 +2,7 @@
   "attributes": {
     "cpe": {
       "description": "CPE—the well-formed CPE name(WFN). WFNs can be used to describe a set of products or to identify an individual product.",
-      "misp-attribute": "text",
+      "misp-attribute": "cpe",
       "ui-priority": 0
     },
     "description": {

--- a/objects/weakness/definition.json
+++ b/objects/weakness/definition.json
@@ -7,7 +7,7 @@
     },
     "id": {
       "description": "Weakness ID (generally CWE).",
-      "misp-attribute": "text",
+      "misp-attribute": "weakness",
       "ui-priority": 0
     },
     "name": {


### PR DESCRIPTION
That would also be usefull for enrichment modules to be available for those attributes within objects, the same way the are available to enrich the equivalent single attributes.

The `weakness` type is generic enough for weaknesses and not bound specifically to CWE, so using text is not required.
For the `cpe` type which is more specific, it is the format intended to be used so we do not need to use `text`.