### PR TITLE
Adding fields in twitter-post and paste

### DIFF
--- a/objects/paste/definition.json
+++ b/objects/paste/definition.json
@@ -25,6 +25,7 @@
       "values_list": [
         "pastebin.com",
         "pastebin.com_pro",
+        "pastebin.fr",
         "pastie.org",
         "slexy.org",
         "gist.github.com",
@@ -40,6 +41,11 @@
       "description": "Raw text of the paste or post",
       "misp-attribute": "text",
       "ui-priority": 1
+    },
+    "paste_file": {
+      "description": "Content of the paste in file",
+      "misp-attribute": "attachment",
+      "ui-priority": 0
     },
     "title": {
       "description": "Title of the paste or post.",
@@ -65,5 +71,5 @@
     "paste"
   ],
   "uuid": "cedc055c-78aa-49a4-bfd7-4cc30cecef12",
-  "version": 5
+  "version": 6
 }

--- a/objects/paste/definition.json
+++ b/objects/paste/definition.json
@@ -42,7 +42,7 @@
       "misp-attribute": "text",
       "ui-priority": 1
     },
-    "paste_file": {
+    "paste-file": {
       "description": "Content of the paste in file",
       "misp-attribute": "attachment",
       "ui-priority": 0

--- a/objects/twitter-post/definition.json
+++ b/objects/twitter-post/definition.json
@@ -12,6 +12,11 @@
       "multiple": true,
       "ui-priority": 1
     },
+    "created-at":{
+      "description": "Datetime of Tweet publication",
+      "misp-attribute": "datetime",
+      "ui-priority": 0
+    },
     "embedded-link": {
       "description": "Link in the tweet",
       "misp-attribute": "url",
@@ -154,5 +159,5 @@
     "attachment"
   ],
   "uuid": "d1214031-ce1b-4a35-bd33-644c707bda2e",
-  "version": 4
+  "version": 5
 }

--- a/objects/twitter-post/definition.json
+++ b/objects/twitter-post/definition.json
@@ -73,6 +73,12 @@
       "multiple": true,
       "ui-priority": 1
     },
+    "media":{
+      "description": "Media (Photos, videos) present in tweet",
+      "misp_attribute": "attachment",
+      "multiple": true,
+      "ui-priority": 0
+    },
     "name": {
       "description": "Name of the account that posted this tweet.",
       "misp-attribute": "text",
@@ -148,5 +154,5 @@
     "attachment"
   ],
   "uuid": "d1214031-ce1b-4a35-bd33-644c707bda2e",
-  "version": 3
+  "version": 4
 }


### PR DESCRIPTION
Add media in twitter-post in order to store attached medias in a tweet

Add pastebin.fr in source of paste and paste_file for storing whole
paste file.