### PR TITLE
Updated for support for msg format.

### DIFF
--- a/objects/email/definition.json
+++ b/objects/email/definition.json
@@ -26,10 +26,17 @@
       "description": "Body of the email",
       "disable_correlation": true,
       "misp-attribute": "email-body",
+      "multiple": true,
       "ui-priority": 1
     },
     "eml": {
       "description": "Full EML",
+      "disable_correlation": true,
+      "misp-attribute": "attachment",
+      "ui-priority": 1
+    },
+    "msg": {
+      "description": "Full MSG",
       "disable_correlation": true,
       "misp-attribute": "attachment",
       "ui-priority": 1
@@ -204,7 +211,8 @@
     "x-mailer",
     "return-path",
     "email-body",
-    "eml"
+    "eml",
+    "msg"
   ],
   "uuid": "a0c666e0-fc65-4be8-b48f-3423d788b552",
   "version": 15


### PR DESCRIPTION
Adding first class support for emails in .msg format to the email definition. This includes making the  attribute support multiple bodies. Msg formatted emails nearly always have at least 2, if not 3, versions of the body (plain text, rtf, html). This pull request will lay the foundation for an upcoming pull requests to PyMisp and then misp-modules which will improve support for email importing (both msg and eml).