### PR TITLE
Creation of Network Profile MISP Object

### DIFF
--- a/objects/network-profile/definition.json
+++ b/objects/network-profile/definition.json
@@ -1,0 +1,218 @@
+{
+  "attributes": {
+    "domain": {
+      "categories": [
+        "Network activity",
+        "External analysis"
+      ],
+      "description": "Domain of the whois entry",
+      "misp-attribute": "domain",
+      "multiple": true,
+      "ui-priority": 0
+    },
+    "ip-address": {
+      "description": "IP address of the whois entry",
+      "misp-attribute": "ip-src",
+      "multiple": true,
+      "ui-priority": 0
+    },
+    "dns-server": {
+      "description": "DNS server",
+      "misp-attribute": "hostname",
+      "multiple": true,
+      "to_ids": false,
+      "ui-priority": 0
+    },
+    "subdomain": {
+      "description": "Subdomain",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 0
+    },
+    "tld": {
+      "description": "Top-Level Domain",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 0
+    },
+    "threat-actor-infrastructure-pattern": {
+      "description": "Patterns found on threat actor infrastructure that can correlate with other analysis.",
+      "misp-attribute": "text",
+      "multiple": true,
+      "ui-priority": 0
+    },
+      "threat-actor-infrastructure-value": {
+      "description": "Unique valeu found on threat actor infrastructure identified through an investigation.",
+      "misp-attribute": "text",
+      "multiple": true,
+      "ui-priority": 0
+    },
+    "hosting-provider": {
+      "description": "The hosting provider/ISP where the resources are.",
+      "misp-attribute": "text",
+      "ui-priority": 0
+    },
+    "port": {
+      "description": "Port number",
+      "disable_correlation": true,
+      "misp-attribute": "port",
+      "ui-priority": 0
+    },
+    "query_string": {
+      "description": "Query (after path, preceded by '?')",
+      "misp-attribute": "text",
+      "multiple": true,
+      "ui-priority": 0
+    },
+    "resource_path": {
+      "description": "Path (between hostname:port and query)",
+      "misp-attribute": "text",
+      "multiple": true,
+      "ui-priority": 0
+    },
+        "jarm": {
+      "description": "JARM Footprint string",
+      "misp-attribute": "text",
+      "ui-priority": 0
+    },
+        "google-analytics-id": {
+      "description": "Google analytics IDS",
+      "misp-attribute": "text",
+      "ui-priority": 0
+    },
+        "certificate-issuer": {
+      "description": "Certificate Issuer",
+      "misp-attribute": "text",
+      "ui-priority": 0
+    },
+        "certificate-common-name": {
+      "description": "Certificate common name",
+      "misp-attribute": "text",
+      "ui-priority": 0
+    },
+        "certificate-organization-unit": {
+      "description": "Certificate organization unit",
+      "misp-attribute": "text",
+      "ui-priority": 0
+    },
+        "certificate-organization": {
+      "description": "Certificate organization",
+      "misp-attribute": "text",
+      "ui-priority": 0
+    },
+        "certificate-organization-locality": {
+      "description": "Certificate locality",
+      "misp-attribute": "text",
+      "ui-priority": 0
+    },
+        "certificate-organization-state": {
+      "description": "Certificate state or provincy name",
+      "misp-attribute": "text",
+      "ui-priority": 0
+    },
+        "certificate-country": {
+      "description": "Certificate country name",
+      "misp-attribute": "text",
+      "ui-priority": 0
+    },
+        "service-abuse": {
+      "description": "Service abused by threat actors as part of their infrastructure.",
+      "misp-attribute": "text",
+      "multiple": true,
+      "ui-priority": 0,
+           "values_list": [
+        "OneDrive",
+        "Google Drive",
+        "Dropbox",
+        "Microsoft",
+                "Google",
+                "DuckDNS",
+                "Cloudflare",
+                "AWS"
+      ]
+    },
+    "asn":{
+        "description": "ASN where the content is hosted",
+        "misp-attribute": "as",
+        "ui-priority":0
+    },
+    "url": {
+      "description": "Full URL",
+      "misp-attribute": "url",
+      "ui-priority": 1
+    },
+    "whois-registrant-email": {
+      "description": "Registrant email address",
+      "misp-attribute": "whois-registrant-email",
+      "ui-priority": 1
+    },
+    "whois-registrant-name": {
+      "description": "Registrant name",
+      "misp-attribute": "whois-registrant-name",
+      "ui-priority": 0
+    },
+    "whois-registrant-org": {
+      "description": "Registrant organisation",
+      "misp-attribute": "whois-registrant-org",
+      "ui-priority": 1
+    },
+    "whois-registrant-phone": {
+      "description": "Registrant phone number",
+      "misp-attribute": "whois-registrant-phone",
+      "ui-priority": 0
+    },
+    "whois-registrar": {
+      "description": "Registrar of the whois entry",
+      "misp-attribute": "whois-registrar",
+      "ui-priority": 0
+    },
+    "whois-creation-date": {
+      "description": "Initial creation of the whois entry",
+      "disable_correlation": true,
+      "misp-attribute": "datetime",
+      "ui-priority": 0
+    },
+    "whois-expiration-date": {
+      "description": "Expiration of the whois entry",
+      "disable_correlation": true,
+      "misp-attribute": "datetime",
+      "ui-priority": 0
+    },
+    "text": {
+      "description": "Full whois entry",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+   "evidences": {
+      "categories": [
+        "External analysis"
+      ],
+      "description": "Screenshot of the network resources.",
+      "disable_correlation": true,
+      "misp-attribute": "attachment",
+      "multiple": true,
+      "ui-priority": 1
+    },
+          "certificate-creation-date": {
+      "description": "Certificate date it was created",
+      "misp-attribute": "datetime",
+      "ui-priority": 0
+    },
+          "certificate-expiry-date": {
+      "description": "Certificate date it will expire",
+      "misp-attribute": "datetime",
+      "ui-priority": 0
+    }
+},
+  "description": "Elements that can be used to profile, pivot or identify a network infrastructure, including domains, ip and urls.",
+  "meta-category": "network",
+  "name": "network-profile",
+  "requiredOneOf": [
+    "domain",
+    "ip-address",
+        "url"
+  ],
+  "uuid": "f0f9e287-8067-49a4-b0f8-7a0fed8d4e43",
+  "version": 4
+}


### PR DESCRIPTION
The idea behind this object is to provide a unique form to identify network artifacts.
It's a mix of different including whois, URL and domain.

The need for a consolidated object comes to group correlated elements.

Beyond that, I'm introducing the idea to use the correlation feature in more generic ways.
Example:

The value of "threat-actor-infrastructure-value" is the unique value observed on a network resource that identify it. A practical and tested example is this resources from Kaspesky.

https://securelist.com/the-tetrade-brazilian-banking-malware/97779/

On this article they mention a trojan family called Javali. They recover the C2 server abusing Google Docs services. The mentioned field "threat-actor-infrastructure-value" would register the values available on this image. This item should be hard to correlate with other similar items, as this can change frequently.

A way to change it is also to register a more general pattern of the data with the "threat-actor-infrastructure-pattern". I.E

inicio{
"host":"<variable>",
"porta":"<variable>"
}fim

With other investigations and registry of it on MISP, is possible to correlate this data, facilitate identification of patterns used for tracking purposes and facilitate analysis.