### PR TITLE
new: add address related relationships

### DIFF
--- a/relationships/definition.json
+++ b/relationships/definition.json
@@ -1163,7 +1163,51 @@
         "misp"
       ],
       "name": "alerts"
+    },
+    {
+      "description": "The referenced source object is the legal address of the target.",
+      "format": [
+        "misp"
+      ],
+      "name": "legal-address-of"
+    },
+    {
+      "description": "The referenced source object is a shipping address of the target.",
+      "format": [
+        "misp"
+      ],
+      "name": "shipping-address-of"
+    },
+    {
+      "description": "The referenced source object visited the target (for example an address).",
+      "format": [
+        "misp"
+      ],
+      "name": "visited"
+    },
+    {
+      "description": "The referenced source object is an office of the target.",
+      "format": [
+        "misp"
+      ],
+      "name": "office-of"
+    },
+    {
+      "description": "The referenced source object is a picture (photo/image) of the target.",
+      "format": [
+        "misp"
+      ],
+      "name": "picture-of",
+      "opposite": "pictured-by"
+    },
+    {
+      "description": "The referenced source object is pictured by the target (photo/image).",
+      "format": [
+        "misp"
+      ],
+      "name": "pictured-by",
+      "opposite": "picture-of"
     }
   ],
-  "version": 24
+  "version": 25
 }


### PR DESCRIPTION
Follow up of #334

If you know a better name for 'pictured-by' I think that would be great, couldn't really come up with any myself.

Somehow that direction is nicer because you can link an object to a single attachment attribute and the picture will show up in the event graph directly. If you add it as file and use picture-of it looks a bit less nice...

![image](https://user-images.githubusercontent.com/9868873/140333204-04cddb3f-7aac-4518-ae8d-27a05a776f4d.png)
