### PR TITLE
chg: add requiredOneOf for postal-address

### DIFF
--- a/objects/postal-address/definition.json
+++ b/objects/postal-address/definition.json
@@ -57,6 +57,11 @@
   "description": "A postal address.",
   "meta-category": "misc",
   "name": "postal-address",
+  "requiredOneOf": [
+    "street",
+    "city",
+    "country"
+  ],
   "uuid": "c22cdd17-d38e-42d3-a365-4febdaaaf25e",
-  "version": 3
+  "version": 4
 }


### PR DESCRIPTION
Hi,

change honestly mostly to make sure label is added to event graph, since it looks like those fields are used:

![image](https://user-images.githubusercontent.com/9868873/146773020-6cbbfb15-404c-440e-b903-7bc4c8bcc10d.png)