### PR TITLE
Add description to ftm-Company object template

### DIFF
--- a/objects/ftm-Company/definition.json
+++ b/objects/ftm-Company/definition.json
@@ -477,7 +477,7 @@
       "ui-priority": 0
     }
   },
-  "description": "",
+  "description": "A legal entity representing an association of people, whether natural, legal or a mixture of both, with a specific objective",
   "meta-category": "followthemoney",
   "name": "ftm-Company",
   "required": [


### PR DESCRIPTION
The empty string value in the description key caused an error when new objects were added to events.