### PR TITLE
Spearphishing objects

### DIFF
--- a/objects/spearphishing-attachment/definition.json
+++ b/objects/spearphishing-attachment/definition.json
@@ -55,6 +55,12 @@
       "misp-attribute": "url",
       "ui-priority": 1
     },
+    "date": {
+      "description": "Date and time the e-mail was sent.",
+      "misp-attribute": "text",
+      "disable_correlation": true,
+      "ui-priority": 0
+    },
     "email-sender": {
       "description": "The source address from which the e-mail was sent.",
       "misp-attribute": "email-src",

--- a/objects/spearphishing-attachment/definition.json
+++ b/objects/spearphishing-attachment/definition.json
@@ -1,0 +1,103 @@
+{
+  "attributes": {
+    "artifact-dropped-md5": {
+      "description": "The MD5 of an additional file that was either extracted from or downloaded by the attachment.",
+      "misp-attribute": "md5",
+      "ui-priority": 1
+    },
+    "artifact-dropped-name": {
+      "description": "Name of an additional file that was either extracted from or downloaded by the attachment.",
+      "misp-attribute": "filename",
+      "ui-priority": 0
+    },
+    "artifact-dropped-sha1": {
+      "description": "The SHA1 of an additional file that was either extracted from or downloaded by the attachment.",
+      "misp-attribute": "sha1",
+      "ui-priority": 1
+    },
+    "artifact-dropped-sha256": {
+      "description": "The SHA256 of an additional file that was either extracted from or downloaded by the attachment.",
+      "misp-attribute": "sha256",
+      "ui-priority": 1
+    },
+    "attachment-md5": {
+      "description": "The MD5 of the file that was attached to the e-mail itself.",
+      "misp-attribute": "md5",
+      "ui-priority": 1
+    },
+    "attachment-name": {
+      "description": "The name of the file that was attached to the e-mail itself.",
+      "misp-attribute": "filename",
+      "ui-priority": 0
+    },
+    "attachment-sha1": {
+      "description": "The SHA1 of the file that was attached to the e-mail itself.",
+      "misp-attribute": "sha1",
+      "ui-priority": 1
+    },
+    "attachment-sha256": {
+      "description": "The SHA256 of the file that was attached to the e-mail itself.",
+      "misp-attribute": "sha256",
+      "ui-priority": 1
+    },
+    "c2-domain": {
+      "description": "Command and control domain detected during analysis.",
+      "misp-attribute": "domain",
+      "ui-priority": 1
+    },
+    "c2-ip": {
+      "description": "Command and control IP address detected during analysis.",
+      "misp-attribute": "ip-dst",
+      "ui-priority": 1
+    },
+    "c2-url": {
+      "description": "Command and control URL detected during analysis.",
+      "misp-attribute": "url",
+      "ui-priority": 1
+    },
+    "email-sender": {
+      "description": "The source address from which the e-mail was sent.",
+      "misp-attribute": "email-src",
+      "ui-priority": 1
+    },
+    "malicious-url": {
+      "description": "Malicious URL that downloaded additional malware.",
+      "misp-attribute": "url",
+      "ui-priority": 1
+    },
+    "research-links": {
+      "description": "A link to an external analysis (VirusTotal, urlscan, etc.).",
+      "misp-attribute": "link",
+      "ui-priority": 0
+    },
+    "sender-ip": {
+      "description": "The source IP from which the e-mail was sent.",
+      "misp-attribute": "ip-src",
+      "ui-priority": 1
+    },
+    "subject": {
+      "description": "The subject line of the e-mail.",
+      "misp-attribute": "email-subject",
+      "ui-priority": 1
+    },
+    "supporting-evidence": {
+      "description": "Description of the spearphish e-mail.",
+      "misp-attribute": "text",
+      "ui-priority": 0
+    }
+  },
+  "description": "Spearphishing Attachment",
+  "meta-category": "network",
+  "name": "spearphishing-attachment",
+  "required": [
+    "email-sender",
+    "subject"
+  ],
+  "requiredOneOf": [
+    "attachment-md5",
+    "attachment-sha1",
+    "attachment-sha256"
+  ],
+  "uuid": "5dfcd9a9-d10c-48ae-9ba4-13c2428a994a",
+  "version": 20220520
+}

--- a/objects/spearphishing-attachment/definition.json
+++ b/objects/spearphishing-attachment/definition.json
@@ -57,8 +57,8 @@
     },
     "date": {
       "description": "Date and time the e-mail was sent.",
-      "misp-attribute": "text",
       "disable_correlation": true,
+      "misp-attribute": "text",
       "ui-priority": 0
     },
     "email-sender": {

--- a/objects/spearphishing-link/definition.json
+++ b/objects/spearphishing-link/definition.json
@@ -2,8 +2,8 @@
   "attributes": {
     "date": {
       "description": "Date and time e-mail was sent.",
-      "misp-attribute": "text",
       "disable_correlation": true,
+      "misp-attribute": "text",
       "ui-priority": 0
     },
     "email-sender": {

--- a/objects/spearphishing-link/definition.json
+++ b/objects/spearphishing-link/definition.json
@@ -1,0 +1,49 @@
+{
+  "attributes": {
+    "email-sender": {
+      "description": "The source address from which the e-mail was sent.",
+      "misp-attribute": "email-src",
+      "ui-priority": 1
+    },
+    "embedded-link": {
+      "description": "The malicious URL in the e-mail body.",
+      "misp-attribute": "url",
+      "ui-priority": 1
+    },
+    "redirect-url": {
+      "description": "The redirect URL, if any, from the malicious embedded link.",
+      "misp-attribute": "url",
+      "ui-priority": 0
+    },
+    "research-links": {
+      "description": "A link to an external analysis (VirusTotal, urlscan, etc.).",
+      "misp-attribute": "link",
+      "ui-priority": 0
+    },
+    "sender-ip": {
+      "description": "The source IP from which the e-mail was sent.",
+      "misp-attribute": "ip-src",
+      "ui-priority": 1
+    },
+    "subject": {
+      "description": "The subject line of the e-mail.",
+      "misp-attribute": "email-subject",
+      "ui-priority": 1
+    },
+    "supporting-evidence": {
+      "description": "Description of the spearphish e-mail.",
+      "misp-attribute": "text",
+      "ui-priority": 0
+    }
+  },
+  "description": "Spearphishing Link",
+  "meta-category": "network",
+  "name": "spearphishing-link",
+  "required": [
+    "email-sender",
+    "subject",
+    "embedded-link"
+  ],
+  "uuid": "4e758e53-6c84-47b0-a19b-362f587059e2",
+  "version": 20220520
+}

--- a/objects/spearphishing-link/definition.json
+++ b/objects/spearphishing-link/definition.json
@@ -1,5 +1,11 @@
 {
   "attributes": {
+    "date": {
+      "description": "Date and time e-mail was sent.",
+      "misp-attribute": "text",
+      "disable_correlation": true,
+      "ui-priority": 0
+    },
     "email-sender": {
       "description": "The source address from which the e-mail was sent.",
       "misp-attribute": "email-src",


### PR DESCRIPTION
In my ISAC we have members who share multiple spearphishing intel in one email. This will allow us to create a singular MISP event and attach each campaign as an object to the event. It will keep the community instance tidier, retain context from the original share, and also allow another member to quickly identify the originating email on the listserv if they needed it for reference.