### PR TITLE
Update definition.json

### DIFF
--- a/objects/security-playbook/definition.json
+++ b/objects/security-playbook/definition.json
@@ -53,7 +53,7 @@
       "ui-priority": 1
     },
     "playbook-id": {
-      "description": "A value that uniquely identifies the playbook. If the playbook itself embeds an identifier then the playbook-id SHOULD use the same identifier (value). If not, the producer MAY generate a unique identifier for the playbook.",
+      "description": "A value that uniquely identifies the playbook.",
       "disable_correlation": false,
       "misp-attribute": "text",
       "ui-priority": 1


### PR DESCRIPTION
updated the description of the playbook-id attribute that was mistakenly proposing to re-use the identifier of an "encapsulated" playbook as the playbook_id of this object.