### PR TITLE
Update definition.json

### DIFF
--- a/objects/security-playbook/definition.json
+++ b/objects/security-playbook/definition.json
@@ -53,7 +53,7 @@
       "ui-priority": 1
     },
     "playbook-id": {
-      "description": "A value that uniquely identifies the playbook. If the playbook itself embeds an identifier then the playbook-id SHOULD use the same identifier (value). If not, the producer MAY generate a unique identifier for the playbook.",
+      "description": "A value that (uniquely) identifies the playbook. If the playbook itself embeds an identifier then the playbook-id SHOULD use the same identifier (value) for correlation purposes.",
       "disable_correlation": false,
       "misp-attribute": "text",
       "ui-priority": 1
@@ -134,9 +134,6 @@
   "description": "The security-playbook object provides meta-information and allows managing, storing, and sharing cybersecurity playbooks and orchestration workflows.",
   "meta-category": "misc",
   "name": "security-playbook",
-  "required": [
-    "playbook-id"
-  ],
   "requiredOneOf": [
     "playbook-file",
     "playbook-base64"


### PR DESCRIPTION
Found the issue and updated the playbook-id attribute. It is not required anymore. We should not dictate producers generating this property since it can be used to correlate playbooks. The use case is: If we have a cacao playbook attached then we could have the UUIDV4 extracted from the "attachment" and put at the MISP security-playbook object attribute "playbook-id". Correlation is enabled if another security playbook object follows the same process while attaching the same CACAO playbook. If the attached playbook is a png then there is no way to associate it again with another security playbook object that has the same png as an attachment as we cannot know that. That would be possible only if the attachment had a machine-readable identifier. Another use case is to generate a hash and attach it to a property, but let's leave that for the future and if it is never needed or appears as a use case. Long story short the pull request improves the semantics of the object and correlations of different security playbook objects :)