### PR TITLE
Added `contact_information` & `sector` attributes to the `organization` template

### DIFF
--- a/objects/organization/definition.json
+++ b/objects/organization/definition.json
@@ -83,7 +83,7 @@
       ]
     },
     "sector": {
-      "description": "Description of the organization sector"
+      "description": "Describing the organization's sector of activity.",
       "misp-attribute": "text",
       "multiple": true,
       "sane_default": [

--- a/objects/organization/definition.json
+++ b/objects/organization/definition.json
@@ -18,6 +18,11 @@
       "multiple": true,
       "ui-priority": 99
     },
+    "contact_information": {
+      "description": "Generic contact information (e-mail, phone number, etc.) for this Organization, with no specific format requirement.",
+      "misp-attribute": "text",
+      "ui-priority": 18
+    },
     "date-of-inception": {
       "description": "Date of inception of the organization",
       "misp-attribute": "datetime",
@@ -76,6 +81,48 @@
         "Informant",
         "Emitter"
       ]
+    },
+    "sector": {
+      "description": "Description of the organization sector"
+      "misp-attribute": "text",
+      "multiple": true,
+      "sane_default": [
+        "agriculture",
+        "aerospace",
+        "automotive",
+        "chemical",
+        "commercial",
+        "communication",
+        "construction",
+        "defense",
+        "education",
+        "energy",
+        "entertainment",
+        "financial-services",
+        "government",
+        "government emergency-services",
+        "government government-local",
+        "government-national",
+        "government-public-services",
+        "government-regional",
+        "healthcare",
+        "hospitality-leasure",
+        "infrastructure",
+        "infrastructure dams",
+        "infrastructure nuclear",
+        "infrastructure water",
+        "insurance",
+        "manufacturing",
+        "mining",
+        "non-profit",
+        "pharmaceuticals",
+        "retail",
+        "technology",
+        "telecommunication",
+        "transportation",
+        "utilities"
+      ],
+      "ui-priority": 17
     },
     "type-of-organization": {
       "description": "Type of the organization",


### PR DESCRIPTION
As it mainly comes from the STIX 2.x Identity object, which has a `contact_information` field where you can put email addresses, phones and other contact information with no specific format requirement, here it is in this template, to make the import from STIX 2.x content easier.
Users can still use the specific object relations such as phone number, address, email addres, and so on.

We also added the `sector` object relation to have information on the sector of activity for the organization.