### PR TITLE
Added a is-malicious attribute for abuseipdb and added a google-safe-…

### DIFF
--- a/objects/abuseipdb/definition.json
+++ b/objects/abuseipdb/definition.json
@@ -1,5 +1,10 @@
 {
   "attributes": {
+    "is-malicious": {
+      "description": "If the IP is malicious based on the abuse-confidence-score and threshold",
+      "misp-attribute": "boolean",
+      "ui-priority": 0
+    },
     "abuse-confidence-score": {
       "description": "Rating (0-100) of how confident AbuseIPDB is that an IP address is entirely malicious",
       "misp-attribute": "counter",

--- a/objects/abuseipdb/definition.json
+++ b/objects/abuseipdb/definition.json
@@ -1,13 +1,13 @@
 {
   "attributes": {
-    "is-malicious": {
-      "description": "If the IP is malicious based on the abuse-confidence-score and threshold",
-      "misp-attribute": "boolean",
-      "ui-priority": 0
-    },
     "abuse-confidence-score": {
       "description": "Rating (0-100) of how confident AbuseIPDB is that an IP address is entirely malicious",
       "misp-attribute": "counter",
+      "ui-priority": 0
+    },
+    "is-malicious": {
+      "description": "If the IP is malicious based on the abuse-confidence-score and threshold",
+      "misp-attribute": "boolean",
       "ui-priority": 0
     },
     "is-public": {

--- a/objects/google-safe-browsing/definition.json
+++ b/objects/google-safe-browsing/definition.json
@@ -1,0 +1,24 @@
+{
+  "attributes": {
+    "malicious": {
+      "description": "If the URL comes back as malicious",
+      "misp-attribute": "boolean",
+      "ui-priority": 0
+    },
+    "platforms": {
+      "description": "The platform identified (windows, linux, etc...)",
+      "misp-attribute": "text",
+      "ui-priority": 0
+    },
+    "threats": {
+      "description": "The threat type related to that URL (malware, social engineering, etc...)",
+      "misp-attribute": "text",
+      "ui-priority": 0
+    }
+  },
+  "description": "Google Safe checks a URL against Google's constantly updated list of unsafe web resources.",
+  "meta-category": "network",
+  "name": "google-safe-browsing",
+  "uuid": "1f8af312-dfbb-4572-b894-dabe7c8798d8",
+  "version": 1
+}


### PR DESCRIPTION
…browsing object for the google-safe-browsing expansion module

The AbuseIPDB object template is used for the AbuseIPDB expansion module, added the is-malicious attribute. The module will determine if the ip or domain is malicious based on the abuse-confidence-score. The expansion module is also changed to add a threshold configuration. If abuse_confidence_score >= abuse_threshold it is flagged as malicious.

The google-safe-browsing object template is used for the google safe browsing expansion module.