### PR TITLE
new misp-object: c2-list

### DIFF
--- a/objects/c2-list/definition.json
+++ b/objects/c2-list/definition.json
@@ -1,0 +1,40 @@
+{
+  "attributes": {
+    "c2": {
+      "categories": [
+        "Network activity"
+      ],
+      "description": "IP:Port of C2 server",
+      "misp-attribute": "ip-src|port",
+      "multiple": true,
+      "ui-priority": 1
+    },
+    "report-url": {
+      "description": "URL of source of information, e.g. blog post, ransomware analysis",
+      "disable_correlation": true,
+      "misp-attribute": "link",
+      "multiple": true,
+      "ui-priority": 1
+    },
+    "threat": {
+      "categories": [
+        "Attribution",
+        "Payload type"
+      ],
+      "description": "threat actor or malware",
+      "misp-attribute": "text",
+      "ui-priority": 1
+    }
+  },
+  "description": "List of C2-servers with common ground, e.g. extracted from a blog post or ransomware analysis",
+  "meta-category": "network",
+  "name": "c2-list",
+  "required": [
+    "threat"
+  ],
+  "requiredOneOf": [
+    "c2"
+  ],
+  "uuid": "12456351-ceb7-4d43-9a7e-d2275d8b5785",
+  "version": 20230919
+}

--- a/objects/c2-list/definition.json
+++ b/objects/c2-list/definition.json
@@ -1,5 +1,14 @@
 {
   "attributes": {
+    "c2-ip": {
+      "categories": [
+        "Network activity"
+      ],
+      "description": "IP of C2 server with unknown port",
+      "misp-attribute": "ip-src",
+      "multiple": true,
+      "ui-priority": 1
+    },
     "c2-ipport": {
       "categories": [
         "Network activity"
@@ -9,15 +18,6 @@
       "multiple": true,
       "ui-priority": 1
     },
-    "c2-ip": {
-      "categories": [
-        "Network activity"
-      ],
-      "description": "IP of C2 server with unknown port",
-      "misp-attribute": "ip-src",
-      "multiple": true,
-      "ui-priority": 1
-    },    
     "report-url": {
       "description": "URL of source of information, e.g. blog post, ransomware analysis",
       "disable_correlation": true,

--- a/objects/c2-list/definition.json
+++ b/objects/c2-list/definition.json
@@ -1,6 +1,6 @@
 {
   "attributes": {
-    "c2": {
+    "c2-ipport": {
       "categories": [
         "Network activity"
       ],
@@ -9,6 +9,15 @@
       "multiple": true,
       "ui-priority": 1
     },
+    "c2-ip": {
+      "categories": [
+        "Network activity"
+      ],
+      "description": "IP of C2 server with unknown port",
+      "misp-attribute": "ip-src",
+      "multiple": true,
+      "ui-priority": 1
+    },    
     "report-url": {
       "description": "URL of source of information, e.g. blog post, ransomware analysis",
       "disable_correlation": true,
@@ -33,7 +42,8 @@
     "threat"
   ],
   "requiredOneOf": [
-    "c2"
+    "c2-ipport",
+    "c2-ip"
   ],
   "uuid": "12456351-ceb7-4d43-9a7e-d2275d8b5785",
   "version": 20230919


### PR DESCRIPTION
adds object for tracking c2 servers found in ransomware reports, blog posts or similar