### PR TITLE
add 'hostname' for scanning host to object 'research-scanner'

### DIFF
--- a/objects/research-scanner/definition.json
+++ b/objects/research-scanner/definition.json
@@ -43,6 +43,16 @@
       "multiple": true,
       "ui-priority": 1
     },
+    "scanning_host": {
+      "categories": [
+        "Network activity",
+        "External analysis"
+      ],
+      "description": "Scanning host used by project",
+      "misp-attribute": "hostname",
+      "multiple": true,
+      "ui-priority": 1
+    },
     "scanning_ip": {
       "categories": [
         "Network activity",


### PR DESCRIPTION
researchers use different hostnames for the scans, e.g. 
- fb02itsscan01.REDACTED.de
- fb02itsscan02.REDACTED.de
- fb02itsscan06.REDACTED.de
..
we want to keep track of those as well