### PR TITLE
new: [misp-object] New ctf-challenge object

### DIFF
--- a/objects/ctf-challenge/definition.json
+++ b/objects/ctf-challenge/definition.json
@@ -1,0 +1,79 @@
+{
+    "description": "Capture-the-flag challenge object as defined by Rectifyq",
+    "meta-category": "misc",
+    "name": "ctf-challenge",
+    "required": [
+        "title"
+    ],
+    "uuid": "f9bb5d47-ff5b-4569-9987-4bb970639a55",
+    "version": 1,
+    "attributes": {
+        "title": {
+            "description": "The name of the challenge",
+            "disable_correlation": true,
+            "misp-attribute": "text",
+            "ui-priority": 4
+        },
+        "description": {
+            "description": "A brief explanation of the challenge",
+            "disable_correlation": true,
+            "misp-attribute": "text",
+            "ui-priority": 2
+        },
+        "category": {
+            "description": "The type of challenge (e.g., web, binary, forensics)",
+            "disable_correlation": true,
+            "misp-attribute": "text",
+            "multiple": true,
+            "ui-priority": 3,
+            "values_list": [
+                "Web",
+                "Reverse Engineering",
+                "Binary Exploitation",
+                "Forensics",
+                "Networking",
+                "Cryptography",
+                "OSINT",
+                "Misc"
+            ]
+        },
+        "points": {
+            "description": "The rewarded points for completing the challenge",
+            "disable_correlation": true,
+            "misp-attribute": "float",
+            "ui-priority": 1
+        },
+        "flag": {
+            "description": "Submitted and accepted CTF Challenge's flag",
+            "disable_correlation": true,
+            "misp-attribute": "text",
+            "ui-priority": 0
+        },
+        "hints": {
+            "description": "Clues to help solve the challenge",
+            "disable_correlation": true,
+            "misp-attribute": "text",
+            "multiple": true,
+            "ui-priority": 1
+        },
+        "attachment": {
+            "description": "Any relevant supporting files or resources that are attached to the challenge",
+            "disable_correlation": true,
+            "multiple": true,
+            "misp-attribute": "attachment",
+            "ui-priority": 1
+        },
+        "max_attempts": {
+            "description": "Maximum tries allowed",
+            "disable_correlation": true,
+            "misp-attribute": "counter",
+            "ui-priority": 1
+        },
+        "solves": {
+            "description": "Number of people who solved the challenge",
+            "disable_correlation": true,
+            "misp-attribute": "counter",
+            "ui-priority": 1
+        }
+    }
+}


### PR DESCRIPTION
### Added new MISP Object - ctf-challenge

Had this idea while participating local Capture The Flag event, to store CTFs challenge questions, and related supporting files into MISP for learning purposes.
You may refer to this article as well for the background of this suggested MISP Object.
https://medium.com/@rectifyq/using-misp-as-a-platform-for-ctf-writeups-e4917186d4bc
