### PR TITLE
Improve OpenTIDE Object

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ for a specific attribute. An optional **to_ids** boolean field to disable the ID
 - [objects/news-agency](https://github.com/MISP/misp-objects/blob/main/objects/news-agency/definition.json) - News agencies compile news and disseminate news in bulk.
 - [objects/news-media](https://github.com/MISP/misp-objects/blob/main/objects/news-media/definition.json) - News media are forms of mass media delivering news to the general public.
 - [objects/open-data-security](https://github.com/MISP/misp-objects/blob/main/objects/open-data-security/definition.json) - An object describing an open dataset available and described under the open data security model. ref. https://github.com/CIRCL/open-data-security.
+- [objects/opentide](https://github.com/MISP/misp-objects/blob/main/objects/opentide/definition.json) - Describes an Open Threat Informed Detection Engineering object. See https://code.europa.eu/ec-digit-s2/opentide
 - [objects/organization](https://github.com/MISP/misp-objects/blob/main/objects/organization/definition.json) - An object which describes an organization.
 - [objects/original-imported-file](https://github.com/MISP/misp-objects/blob/main/objects/original-imported-file/definition.json) - Object describing the original file used to import data in MISP.
 - [objects/paloalto-threat-event](https://github.com/MISP/misp-objects/blob/main/objects/paloalto-threat-event/definition.json) - Palo Alto Threat Log Event.

--- a/README.md
+++ b/README.md
@@ -312,7 +312,6 @@ for a specific attribute. An optional **to_ids** boolean field to disable the ID
 - [objects/news-agency](https://github.com/MISP/misp-objects/blob/main/objects/news-agency/definition.json) - News agencies compile news and disseminate news in bulk.
 - [objects/news-media](https://github.com/MISP/misp-objects/blob/main/objects/news-media/definition.json) - News media are forms of mass media delivering news to the general public.
 - [objects/open-data-security](https://github.com/MISP/misp-objects/blob/main/objects/open-data-security/definition.json) - An object describing an open dataset available and described under the open data security model. ref. https://github.com/CIRCL/open-data-security.
-- [objects/opentide](https://github.com/MISP/misp-objects/blob/main/objects/opentide/definition.json) - Describes an Open Threat Informed Detection Engineering object. See https://code.europa.eu/ec-digit-s2/opentide
 - [objects/organization](https://github.com/MISP/misp-objects/blob/main/objects/organization/definition.json) - An object which describes an organization.
 - [objects/original-imported-file](https://github.com/MISP/misp-objects/blob/main/objects/original-imported-file/definition.json) - Object describing the original file used to import data in MISP.
 - [objects/paloalto-threat-event](https://github.com/MISP/misp-objects/blob/main/objects/paloalto-threat-event/definition.json) - Palo Alto Threat Log Event.

--- a/objects/opentide/definition.json
+++ b/objects/opentide/definition.json
@@ -31,7 +31,9 @@
       "description": "Version of the OpenTIDE Object",
       "disable_correlation": true,
       "misp-attribute": "text",
-      "sane_default": "1",
+      "sane_default": [
+        "1"
+      ],
       "ui-priority": 2
     }
   },
@@ -39,7 +41,9 @@
   "meta-category": "misc",
   "name": "opentide",
   "required": [
+    "name",
     "uuid",
+    "version",
     "opentide-object",
     "opentide-type"
   ],

--- a/objects/opentide/definition.json
+++ b/objects/opentide/definition.json
@@ -8,14 +8,14 @@
     "opentide-object": {
       "description": "YAML Content of the Opentide Object",
       "misp-attribute": "text",
-      "ui-priority": 3
+      "ui-priority": 4
     },
     "opentide-type": {
       "description": "Type of the OpenTIDE Object",
       "disable_correlation": true,
       "misp-attribute": "text",
       "multiple": false,
-      "ui-priority": 2,
+      "ui-priority": 3,
       "values_list": [
         "tvm",
         "cdm",
@@ -26,6 +26,13 @@
       "description": "UUID of the OpenTIDE Object",
       "misp-attribute": "text",
       "ui-priority": 1
+    },
+    "version": {
+      "description": "Version of the OpenTIDE Object",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "sane_default": "1",
+      "ui-priority": 2
     }
   },
   "description": "Object that is a container for threat or detection data, in accordance with the OpenTIDE Framework (https://code.europa.eu/ec-digit-s2/opentide)",

--- a/objects/opentide/definition.json
+++ b/objects/opentide/definition.json
@@ -1,52 +1,58 @@
 {
-  "attributes": {
-    "name": {
-      "description": "Name of the OpenTIDE Object",
-      "misp-attribute": "text",
-      "ui-priority": 4
-    },
-    "opentide-object": {
-      "description": "YAML Content of the Opentide Object",
-      "misp-attribute": "text",
-      "ui-priority": 0
-    },
-    "opentide-type": {
-      "description": "Type of the OpenTIDE Object",
-      "disable_correlation": true,
-      "misp-attribute": "text",
-      "multiple": false,
-      "ui-priority": 1,
-      "values_list": [
-        "tvm",
-        "cdm",
-        "mdr"
-      ]
-    },
-    "uuid": {
-      "description": "UUID of the OpenTIDE Object",
-      "misp-attribute": "text",
-      "ui-priority": 3
-    },
-    "version": {
-      "description": "Version of the OpenTIDE Object",
-      "disable_correlation": true,
-      "misp-attribute": "text",
-      "sane_default": [
-        "1"
-      ],
-      "ui-priority": 2
-    }
-  },
-  "description": "Object that is a container for threat or detection data, in accordance with the OpenTIDE Framework (https://code.europa.eu/ec-digit-s2/opentide)",
-  "meta-category": "misc",
-  "name": "opentide",
-  "required": [
-    "name",
-    "uuid",
-    "version",
-    "opentide-object",
-    "opentide-type"
-  ],
-  "uuid": "892fd46a-f69e-455c-8c4f-843a4b8f4295",
-  "version": 2
+   "attributes":{
+      "name":{
+         "description":"Name of the OpenTIDE Object",
+         "misp-attribute":"text",
+         "ui-priority":5
+      },
+      "opentide-object":{
+         "description":"YAML Content of the Opentide Object",
+         "misp-attribute":"text",
+         "ui-priority":0
+      },
+      "opentide-type":{
+         "description":"Type of the OpenTIDE Object",
+         "disable_correlation":true,
+         "misp-attribute":"text",
+         "multiple":false,
+         "ui-priority":1,
+         "values_list":[
+            "tvm",
+            "cdm",
+            "mdr"
+         ]
+      },
+      "opentide-relation":{
+         "description":"UUID of other OpenTIDE Objects with a relation to this Object",
+         "misp-attribute":"text",
+         "multiple":true,
+         "ui-priority":1
+      },
+      "uuid":{
+         "description":"UUID of the OpenTIDE Object",
+         "misp-attribute":"text",
+         "ui-priority":4
+      },
+      "version":{
+         "description":"Version of the OpenTIDE Object",
+         "disable_correlation":true,
+         "misp-attribute":"text",
+         "sane_default":[
+            "1"
+         ],
+         "ui-priority":3
+      }
+   },
+   "description":"Object that is a container for threat or detection data, in accordance with the OpenTIDE Framework (https://code.europa.eu/ec-digit-s2/opentide)",
+   "meta-category":"misc",
+   "name":"opentide",
+   "required":[
+      "name",
+      "uuid",
+      "version",
+      "opentide-object",
+      "opentide-type"
+   ],
+   "uuid":"892fd46a-f69e-455c-8c4f-843a4b8f4295",
+   "version":3
 }

--- a/objects/opentide/definition.json
+++ b/objects/opentide/definition.json
@@ -3,19 +3,19 @@
     "name": {
       "description": "Name of the OpenTIDE Object",
       "misp-attribute": "text",
-      "ui-priority": 0
+      "ui-priority": 4
     },
     "opentide-object": {
       "description": "YAML Content of the Opentide Object",
       "misp-attribute": "text",
-      "ui-priority": 4
+      "ui-priority": 0
     },
     "opentide-type": {
       "description": "Type of the OpenTIDE Object",
       "disable_correlation": true,
       "misp-attribute": "text",
       "multiple": false,
-      "ui-priority": 3,
+      "ui-priority": 1,
       "values_list": [
         "tvm",
         "cdm",
@@ -25,7 +25,7 @@
     "uuid": {
       "description": "UUID of the OpenTIDE Object",
       "misp-attribute": "text",
-      "ui-priority": 1
+      "ui-priority": 3
     },
     "version": {
       "description": "Version of the OpenTIDE Object",
@@ -44,5 +44,5 @@
     "opentide-type"
   ],
   "uuid": "892fd46a-f69e-455c-8c4f-843a4b8f4295",
-  "version": 1
+  "version": 2
 }


### PR DESCRIPTION
- Adds a version attribute, to describe the version of the OpenTIDE object itself. Default value of 1.
- Re-orders the UI Priority, so that the object name appears first, then uuid, version, opentide-type, then opentide-object
- Make name a required value
- Update the README object listing to contain an entry for opentide