### PR TITLE
chg: update `ui-priority` in `sigma`/`yara` object templates

### DIFF
--- a/objects/sigma/definition.json
+++ b/objects/sigma/definition.json
@@ -43,5 +43,5 @@
     "sigma-rule-name"
   ],
   "uuid": "aa21a3cd-ab2c-442a-9999-a5e6626591ec",
-  "version": 3
+  "version": 2
 }

--- a/objects/yara/definition.json
+++ b/objects/yara/definition.json
@@ -50,5 +50,5 @@
     "yara-rule-name"
   ],
   "uuid": "b5acf82e-ecca-4868-82fe-9dbdf4d808c3",
-  "version": 8
+  "version": 7
 }


### PR DESCRIPTION
Thank you for maintaining misp-galaxy :)

Currently, `Yara` and `Sigma` objects do not have `ui-priority` set by default. This makes other attrubutes harder to spot when viewing events in a collapsed(when clicking `Collapse all Attributes`)  or aggregated view.

In this PR, I have set the `ui-priority` of the rule titles to `1`. This ensures that the rule's titles are displayed at the top, as shown in the screenshot below.

I would appreciate your feedback.