### PR TITLE
Add JA4 signatures for login attempts

### DIFF
--- a/objects/spearphishing-campaign/definition.json
+++ b/objects/spearphishing-campaign/definition.json
@@ -42,6 +42,24 @@
       "multiple": true,
       "ui-priority": 1
     },
+    "mitm-connect-back-ja4": {
+      "description": "JA4 signature used by the TA for log in attempts",
+      "misp-attribute": "text",
+      "multiple": true,
+      "ui-priority": 1
+    },
+    "mitm-connect-back-ja4http": {
+      "description": "JA4HTTP signature used by the TA for log in attempts",
+      "misp-attribute": "text",
+      "multiple": true,
+      "ui-priority": 1
+    },
+    "mitm-connect-back-ja4tcp": {
+      "description": "JA4TCP signature used by the TA for log in attempts",
+      "misp-attribute": "text",
+      "multiple": true,
+      "ui-priority": 1
+    },
     "phishing-domain": {
       "description": "Domain where the phishing stages are hosted",
       "misp-attribute": "domain",
@@ -72,5 +90,5 @@
     "phishing-domain"
   ],
   "uuid": "20241206-9e59-4b7d-9e88-951458f10a5f",
-  "version": 20250919
+  "version": 20260112
 }


### PR DESCRIPTION
Added dedicated fields to document JA4, JA4HTTP & JA4TCP signatures when a TA / phishing kit attempts to authenticate toward a service, typically Entra.

As an example, Entra records since December 2025 JA4 signatures in field GatewayJA4.

We use misp-attribute `text` to store these signatures, as JA4 [is currently only modelled as a MISP object](https://github.com/MISP/MISP/issues/9759).