### PR TITLE
chg: [vulnerability] update `ui-priority` to ensure CVE-ID is displayed at the top

### DIFF
--- a/objects/vulnerability/definition.json
+++ b/objects/vulnerability/definition.json
@@ -34,7 +34,7 @@
       "description": "Vulnerability ID (generally CVE, but not necessarely). The id is not required as the object itself has an UUID and the CVE id can be update or assigned later.",
       "misp-attribute": "vulnerability",
       "multiple": true,
-      "ui-priority": 0
+      "ui-priority": 2
     },
     "impact": {
       "description": "Impact of the vulnerability",
@@ -107,5 +107,5 @@
     "payload"
   ],
   "uuid": "81650945-f186-437b-8945-9f31715d32da",
-  "version": 11
+  "version": 12
 }


### PR DESCRIPTION
#### What does it do?
I have updated the `ui-priority` of the **id(CVE-ID) for vulnerability objects** so that it is displayed **at the top**.

IMHO, within the context of vulnerability-related information —such as incidents involving exploitation or emergency alerts—the `CVE-ID` is typically a high priority for users. The `CVE-ID` typically serves as the primary baseline for information gathering and dissemination. Prioritizing it at the top helps users grasp the context more intuitively.

I would appreciate your feedback. Thank you for your time.

#### Current behavior
<img width="1710" height="1107" alt="スクリーンショット 2026-02-02 21 42 53" src="https://github.com/user-attachments/assets/90c8a8ef-1776-4062-a8b8-b9e9b9f23082" />
<img width="1710" height="1107" alt="スクリーンショット 2026-02-02 21 50 23" src="https://github.com/user-attachments/assets/af920a7c-6f96-45e3-bb16-7c51a419b8eb" />

#### Behavior after this PR 
<img width="1710" height="1107" alt="スクリーンショット 2026-02-02 21 53 57" src="https://github.com/user-attachments/assets/996d1e61-01e9-43a1-9714-36ebd9340c7c" />
<img width="1710" height="1107" alt="スクリーンショット 2026-02-02 21 54 02" src="https://github.com/user-attachments/assets/9c951fd3-7bfc-4abf-9273-081e32f98fb4" />