### PR TITLE
chg: set dom instead of cdm

### DIFF
--- a/objects/opentide/definition.json
+++ b/objects/opentide/definition.json
@@ -24,7 +24,7 @@
       "ui-priority": 1,
       "values_list": [
         "tvm",
-        "cdm",
+        "dom",
         "mdr"
       ]
     },
@@ -54,5 +54,5 @@
     "version"
   ],
   "uuid": "892fd46a-f69e-455c-8c4f-843a4b8f4295",
-  "version": 3
+  "version": 4
 }


### PR DESCRIPTION
In [opentide](https://github.com/orgs/OpenTideHQ/discussions/30) we have replaced 'Cyber Detection' by 'Detection Objective' a richer expression of signals and compound detections.