### PR TITLE
Add rulezet-bundle MISP object template

### DIFF
--- a/objects/rulezet-bundle/definition.json
+++ b/objects/rulezet-bundle/definition.json
@@ -1,0 +1,121 @@
+{
+  "attributes": {
+    "access": {
+      "description": "Access level of the bundle.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 0
+    },
+    "author": {
+      "description": "Author name associated with the bundle.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "created-at": {
+      "description": "Bundle creation timestamp.",
+      "disable_correlation": true,
+      "misp-attribute": "datetime",
+      "ui-priority": 0
+    },
+    "created-by": {
+      "description": "Creator identifier of the bundle.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 0
+    },
+    "description": {
+      "description": "Description of the bundle.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "download-count": {
+      "description": "Number of times the bundle has been downloaded.",
+      "disable_correlation": true,
+      "misp-attribute": "counter",
+      "ui-priority": 0
+    },
+    "is-verified": {
+      "description": "Whether the bundle has been verified.",
+      "disable_correlation": true,
+      "misp-attribute": "boolean",
+      "ui-priority": 0
+    },
+    "name": {
+      "description": "Name of the bundle.",
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "number-of-rules": {
+      "description": "Total number of rules in the bundle.",
+      "disable_correlation": true,
+      "misp-attribute": "counter",
+      "ui-priority": 1
+    },
+    "rule-format": {
+      "description": "Format used by rules within the bundle (for example Sigma, YARA, Suricata).",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "multiple": true,
+      "ui-priority": 1
+    },
+    "updated-at": {
+      "description": "Timestamp of the last bundle update.",
+      "disable_correlation": true,
+      "misp-attribute": "datetime",
+      "ui-priority": 0
+    },
+    "user-id": {
+      "description": "User identifier owning the bundle.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 0
+    },
+    "user-name": {
+      "description": "Display name of the user owning the bundle.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 0
+    },
+    "uuid": {
+      "description": "UUID assigned to the bundle.",
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "view-count": {
+      "description": "Number of views for the bundle.",
+      "disable_correlation": true,
+      "misp-attribute": "counter",
+      "ui-priority": 0
+    },
+    "vote-down": {
+      "description": "Number of downvotes for the bundle.",
+      "disable_correlation": true,
+      "misp-attribute": "counter",
+      "ui-priority": 0
+    },
+    "vote-up": {
+      "description": "Number of upvotes for the bundle.",
+      "disable_correlation": true,
+      "misp-attribute": "counter",
+      "ui-priority": 0
+    },
+    "vulnerability-identifier": {
+      "description": "Vulnerability identifiers associated with the bundle.",
+      "disable_correlation": true,
+      "misp-attribute": "vulnerability",
+      "multiple": true,
+      "ui-priority": 1
+    }
+  },
+  "description": "Rulezet bundle metadata object representing bundle ownership, activity metrics, verification status and related vulnerabilities.",
+  "meta-category": "misc",
+  "name": "rulezet-bundle",
+  "required": [
+    "name",
+    "uuid"
+  ],
+  "uuid": "0c637129-cf3f-4f74-a517-af20185cbd2a",
+  "version": 1
+}


### PR DESCRIPTION
### Motivation
- Provide a MISP object template that represents a Rulezet bundle metadata record derived from the specified database structure for use in MISP and related tooling.
- Capture ownership, timestamps, access, activity counters, verification status, rule formats and vulnerability identifiers so bundles can be linked and queried consistently alongside existing rule metadata objects.

### Description
- Added `objects/rulezet-bundle/definition.json` which defines a new `rulezet-bundle` object with `meta-category: misc`, `version: 1`, and a UUID.
- Mapped database fields to MISP attributes including `name`, `description`, `created-at`, `updated-at`, `author`, `user-id`/`user-name`, `created-by`, `access`, `vote-up`/`vote-down`, `view-count`, `download-count`, `number-of-rules`, `rule-format` (multi-value), `vulnerability-identifier` (multi-value), and `uuid` as required fields.
- Chose MISP-compatible attribute types (`text`, `datetime`, `counter`, `boolean`, `vulnerability`) and set `name` and `uuid` as required attributes.
- Ensured the JSON file is normalized/sorted to project conventions via the repository's JSON tooling.

### Testing
- Ran `./jq_all_the_things.sh` to normalize and sort JSON files and it completed successfully.
- Verified JSON syntax with `jq empty objects/rulezet-bundle/definition.json` and `python3 -m json.tool objects/rulezet-bundle/definition.json`, both of which succeeded.
- Attempted schema validation with `jsonschema -i objects/rulezet-bundle/definition.json schema_objects.json` which failed because the `jsonschema` CLI is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d91cf3f2dc8324a4b4bfe1cd4e006d)