### PR TITLE
pcap-metadata: add capture/file attributes, hashes, metrics, and bump version

### DIFF
--- a/objects/pcap-metadata/definition.json
+++ b/objects/pcap-metadata/definition.json
@@ -1,5 +1,41 @@
 {
   "attributes": {
+    "capture-application": {
+      "description": "Name of the application used to perform the packet capture.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "sane_default": [
+        "tcpdump",
+        "dumpcap",
+        "Wireshark",
+        "tshark",
+        "WinDump",
+        "Npcap",
+        "netsniff-ng",
+        "ngrep",
+        "snort",
+        "suricata",
+        "Zeek",
+        "Arkime",
+        "NetworkMiner",
+        "Kismet",
+        "CloudShark",
+        "termshark"
+      ],
+      "ui-priority": 1
+    },
+    "capture-filter": {
+      "description": "Capture filter used when recording packets.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "capture-hardware": {
+      "description": "Hardware details of the capture device.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
     "capture-interface": {
       "description": "Interface name where the packet capture was running.",
       "disable_correlation": true,
@@ -10,6 +46,84 @@
       "description": "Capture length set on the captured interface.",
       "disable_correlation": true,
       "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "capture-operating-system": {
+      "description": "Operating system used by the capture device.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "captured-packets": {
+      "description": "Number of packets captured in the packet capture file.",
+      "disable_correlation": true,
+      "misp-attribute": "counter",
+      "ui-priority": 1
+    },
+    "displayed-packets": {
+      "description": "Number of displayed packets.",
+      "disable_correlation": true,
+      "misp-attribute": "counter",
+      "ui-priority": 1
+    },
+    "dropped-packets": {
+      "description": "Number of dropped packets during capture.",
+      "disable_correlation": true,
+      "misp-attribute": "counter",
+      "ui-priority": 1
+    },
+    "elapsed-time": {
+      "description": "Elapsed time between first and last packet seen.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "encapsulation": {
+      "description": "Packet encapsulation format used in the capture.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "file-format": {
+      "description": "Capture file format.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "file-hash-md5": {
+      "description": "MD5 hash of the packet capture file.",
+      "disable_correlation": true,
+      "misp-attribute": "md5",
+      "ui-priority": 1
+    },
+    "file-hash-ripemd160": {
+      "description": "RIPEMD160 hash of the packet capture file.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "file-hash-sha1": {
+      "description": "SHA1 hash of the packet capture file.",
+      "disable_correlation": true,
+      "misp-attribute": "sha1",
+      "ui-priority": 1
+    },
+    "file-hash-sha256": {
+      "description": "SHA256 hash of the packet capture file.",
+      "disable_correlation": true,
+      "misp-attribute": "sha256",
+      "ui-priority": 1
+    },
+    "file-name": {
+      "description": "Name of the packet capture file.",
+      "disable_correlation": true,
+      "misp-attribute": "filename",
+      "ui-priority": 1
+    },
+    "file-size-in-bytes": {
+      "description": "Size of the packet capture file in bytes.",
+      "disable_correlation": true,
+      "misp-attribute": "size-in-bytes",
       "ui-priority": 1
     },
     "first-packet-seen": {
@@ -23,6 +137,18 @@
       "disable_correlation": true,
       "misp-attribute": "datetime",
       "ui-priority": 0
+    },
+    "marked-packets": {
+      "description": "Number of marked packets.",
+      "disable_correlation": true,
+      "misp-attribute": "counter",
+      "ui-priority": 1
+    },
+    "packet-size-limit": {
+      "description": "Packet size limit (snapshot length) in bytes.",
+      "disable_correlation": true,
+      "misp-attribute": "size-in-bytes",
+      "ui-priority": 1
     },
     "protocol": {
       "description": "Capture protocol (linktype name).",
@@ -238,6 +364,12 @@
       "disable_correlation": true,
       "misp-attribute": "text",
       "ui-priority": 1
+    },
+    "time-span-seconds": {
+      "description": "Time span of the packet capture in seconds.",
+      "disable_correlation": true,
+      "misp-attribute": "float",
+      "ui-priority": 1
     }
   },
   "description": "Network packet capture metadata",
@@ -249,5 +381,5 @@
     "last-packet-seen"
   ],
   "uuid": "0784aefa-ec3a-4eca-a431-c31ed7058bd3",
-  "version": 2
+  "version": 3
 }


### PR DESCRIPTION
### Motivation
- Enrich `pcap-metadata` to capture more detailed information about packet captures for improved analysis and triage. 
- Provide common file-level metadata and checksum attributes to support integrity checks and tooling integrations. 
- Expose capture metrics and environment details to aid filtering, reporting, and automated processing.

### Description
- Added multiple new attributes to `pcap-metadata` including `capture-application`, `capture-filter`, `capture-hardware`, `capture-operating-system`, `captured-packets`, `displayed-packets`, `dropped-packets`, `elapsed-time`, `encapsulation`, `file-format`, `file-hash-md5`, `file-hash-ripemd160`, `file-hash-sha1`, `file-hash-sha256`, `file-name`, `file-size-in-bytes`, `marked-packets`, `packet-size-limit`, and `time-span-seconds` with appropriate `misp-attribute` types and `ui-priority` settings. 
- Added sane defaults for `capture-application` and kept/extended existing `protocol` sane list, and ensured `capture-interface`, `first-packet-seen`, `last-packet-seen`, and `text` remain available as required alternatives. 
- Bumped the schema `version` from `2` to `3` to reflect the compatibility-changing additions.

### Testing
- Ran the project schema validation against the updated `objects/pcap-metadata/definition.json` and it succeeded. 
- Executed the repository's automated unit test suite in CI and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da0b89b6748324b84b8dac06542889)