### PR TITLE
Align object template names with directory names

### DIFF
--- a/objects/diamond/definition.json
+++ b/objects/diamond/definition.json
@@ -93,7 +93,7 @@
   },
   "description": "A diamond model event object consisting of the four diamond features advesary, infrastructure, capability and victim, several meta-features and ioc attributes.",
   "meta-category": "internal",
-  "name": "diamond-event",
+  "name": "diamond",
   "required": [
     "EventID",
     "Advesary",

--- a/objects/generalizing-persuasion-framework/definition.json
+++ b/objects/generalizing-persuasion-framework/definition.json
@@ -115,7 +115,7 @@
       "ui-priority": 110
     },
     "settings_time": {
-      "description": "Pretreatment effects—what happened prior to the persuasive message. Posttreatment duration—how long an effect lasts. Time between exposure and outcome measurement.",
+      "description": "Pretreatment effects\u2014what happened prior to the persuasive message. Posttreatment duration\u2014how long an effect lasts. Time between exposure and outcome measurement.",
       "disable_correlation": true,
       "misp-attribute": "text",
       "multiple": true,
@@ -145,7 +145,7 @@
   },
   "description": "By placing their work within the GP Framework, scholars will help the field resolve inconsistencies, identify and address open questions, and ensure collective progress. The GP Framework is not meant to compete with other theories (such as the ELM) but rather to fill in two gaps. First, it allows one to consider how individual persuasion studies connect to one another and why studies may arrive at contradictory conclusions. Second, it highlights the sources of variations that should be studied. (James N. Druckman)",
   "meta-category": "misc",
-  "name": "Generalizing Persuasion Framework",
+  "name": "generalizing-persuasion-framework",
   "uuid": "dc6cdc5f-17d7-4d7b-95fe-86478990c910",
   "version": 1
 }

--- a/objects/nse-script/definition.json
+++ b/objects/nse-script/definition.json
@@ -93,7 +93,7 @@
   },
   "description": "An object describing an Nmap NSE script using the standard NSE script format fields.",
   "meta-category": "network",
-  "name": "nse",
+  "name": "nse-script",
   "requiredOneOf": [
     "nse",
     "nse-script-name"

--- a/objects/persnona/definition.json
+++ b/objects/persnona/definition.json
@@ -94,7 +94,7 @@
   },
   "description": "Fake persona with tasks",
   "meta-category": "misc",
-  "name": "Deception PersNOna",
+  "name": "persnona",
   "required": [
     "name"
   ],

--- a/objects/rulezet-metadata/definition.json
+++ b/objects/rulezet-metadata/definition.json
@@ -116,7 +116,7 @@
   },
   "description": "Rule set metadata object meant to be linked to rule content objects such as YARA, NSE, Sigma or similar templates.",
   "meta-category": "misc",
-  "name": "ruleset-metadata",
+  "name": "rulezet-metadata",
   "required": [
     "title",
     "uuid"

--- a/objects/taranis-news-item/definition.json
+++ b/objects/taranis-news-item/definition.json
@@ -60,7 +60,7 @@
   },
   "description": "An object describing a news item from Taranis AI",
   "meta-category": "misc",
-  "name": "Taranis AI News Item",
+  "name": "taranis-news-item",
   "uuid": "e4b7e5e3-2c4c-4edf-b9a3-2c2a32844e62",
   "version": 2
 }


### PR DESCRIPTION
### Motivation
- Ensure the top-level `"name"` value in each object template exactly matches its containing directory slug to avoid tooling and lookup inconsistencies.

### Description
- Updated the top-level `name` field in six templates so the value exactly matches the directory name: `objects/diamond`, `objects/generalizing-persuasion-framework`, `objects/nse-script`, `objects/persnona`, `objects/rulezet-metadata`, and `objects/taranis-news-item`.
- Only the `name` string values were changed; no other schema attributes or structure were modified.

### Testing
- Ran a repository-wide Python check that compares each `objects/<dir>/definition.json` `name` against its directory and the script returned no mismatches, indicating success.
- Used `rg -n '"name"'` to inspect the updated files and confirm the new `name` values are present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1b0958d1c83248fe78215a8184a41)