### PR TITLE
Enhance malicious-package-report object with OSV credits, purl, and reference-type; bump version

### DIFF
--- a/objects/malicious-package-report/definition.json
+++ b/objects/malicious-package-report/definition.json
@@ -14,10 +14,36 @@
       "ui-priority": 8
     },
     "analysis": {
-      "description": "Behavioral details explaining why the package is malicious (payload, trigger, campaign, impact).",
+      "description": "Behavioral details explaining why the package is malicious (payload, trigger, campaign, impact), typically sourced from OSV summary/details and related contextual fields.",
       "disable_correlation": true,
       "misp-attribute": "text",
       "ui-priority": 7
+    },
+    "credit": {
+      "description": "Credit entry from OSV credits[].name (person, team, or organization acknowledged for discovery, analysis, or remediation).",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "multiple": true,
+      "ui-priority": 5
+    },
+    "credit-role": {
+      "description": "Role annotation from OSV credits[].type (e.g. FINDER, ANALYST, COORDINATOR, REMEDIATION_DEVELOPER, REMEDIATION_REVIEWER, REMEDIATION_VERIFIER, TOOL, SPONSOR, OTHER).",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "multiple": true,
+      "sane_default": [
+        "ANALYST",
+        "COORDINATOR",
+        "FINDER",
+        "OTHER",
+        "REMEDIATION_DEVELOPER",
+        "REMEDIATION_REVIEWER",
+        "REMEDIATION_VERIFIER",
+        "REPORTER",
+        "SPONSOR",
+        "TOOL"
+      ],
+      "ui-priority": 5
     },
     "ecosystem": {
       "description": "Package ecosystem from OSV package.ecosystem (e.g. npm, PyPI, Maven, Go).",
@@ -61,11 +87,36 @@
       "misp-attribute": "text",
       "ui-priority": 10
     },
+    "package-purl": {
+      "description": "Package URL from OSV package.purl (preferred package identifier for correlation across advisories and ecosystems).",
+      "misp-attribute": "text",
+      "ui-priority": 10
+    },
     "reference": {
       "description": "Reference URL to advisories, source reports, or related analysis.",
       "disable_correlation": true,
       "misp-attribute": "link",
       "multiple": true,
+      "ui-priority": 6
+    },
+    "reference-type": {
+      "description": "Reference kind from OSV references[].type (e.g. ADVISORY, ARTICLE, REPORT, DETECTION, FIX, INTRODUCED, EVIDENCE, WEB).",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "multiple": true,
+      "sane_default": [
+        "ADVISORY",
+        "ARTICLE",
+        "DETECTION",
+        "DISCUSSION",
+        "EVIDENCE",
+        "FIX",
+        "GIT",
+        "INTRODUCED",
+        "PACKAGE",
+        "REPORT",
+        "WEB"
+      ],
       "ui-priority": 6
     },
     "report-id": {
@@ -99,5 +150,5 @@
     "report-id"
   ],
   "uuid": "2f8a8711-6ef8-4a9d-89de-f547670573cb",
-  "version": 1
+  "version": 4
 }


### PR DESCRIPTION
### Motivation
- Enrich the `malicious-package-report` object to better capture OSV-origin metadata such as credits, reference kinds, and package URLs for improved attribution and correlation.
- Clarify the `analysis` field to indicate common sourcing from OSV summaries and related contextual fields.
- Bump the object version to reflect the backwards-incompatible schema additions.

### Description
- Extended the `analysis` description to note that it is typically sourced from OSV summary/details and contextual fields.
- Added `credit` and `credit-role` attributes to capture OSV `credits[]` entries and roles, with `credit-role` providing a `sane_default` list of common role values.
- Added `package-purl` attribute to store the OSV `package.purl` for better cross-advisory correlation.
- Added `reference-type` attribute to capture OSV `references[].type` values with a `sane_default` list, and bumped `version` from `1` to `4`.

### Testing
- Ran JSON/schema validation for object definitions and repository linters against the modified `definition.json`, and the checks completed successfully.
- No changes were made to existing unit tests, and no test failures were observed when validating the updated schema.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01a87ca5a88324a24a9125afea1920)