### PR TITLE
Add CTI Transmute conversion object template

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ for a specific attribute. An optional **to_ids** boolean field to disable the ID
 - [objects/cryptocurrency-transaction](https://github.com/MISP/misp-objects/blob/main/objects/cryptocurrency-transaction/definition.json) - An object to describe a cryptocurrency transaction.
 - [objects/cs-beacon-config](https://github.com/MISP/misp-objects/blob/main/objects/cs-beacon-config/definition.json) - Cobalt Strike Beacon Config.
 - [objects/ctf-challenge](https://github.com/MISP/misp-objects/blob/main/objects/ctf-challenge/definition.json) - Capture-the-flag challenge object as defined by Rectifyq.
+- [objects/cti-transmute-conversion](https://github.com/MISP/misp-objects/blob/main/objects/cti-transmute-conversion/definition.json) - CTI Transmute conversion record describing MISP to STIX or STIX to MISP conversion metadata, inputs, outputs, status, and detail link.
 - [objects/cytomic-orion-file](https://github.com/MISP/misp-objects/blob/main/objects/cytomic-orion-file/definition.json) - Cytomic Orion File Detection.
 - [objects/cytomic-orion-machine](https://github.com/MISP/misp-objects/blob/main/objects/cytomic-orion-machine/definition.json) - Cytomic Orion File at Machine Detection.
 - [objects/dark-pattern-item](https://github.com/MISP/misp-objects/blob/main/objects/dark-pattern-item/definition.json) - An Item whose User Interface implements a dark pattern.

--- a/objects/cti-transmute-conversion/definition.json
+++ b/objects/cti-transmute-conversion/definition.json
@@ -1,0 +1,127 @@
+{
+  "attributes": {
+    "conversion_type": {
+      "description": "Direction of the CTI conversion.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "sane_default": [
+        "MISP_TO_STIX",
+        "STIX_TO_MISP"
+      ],
+      "ui-priority": 1,
+      "values_list": [
+        "MISP_TO_STIX",
+        "STIX_TO_MISP"
+      ]
+    },
+    "created_at": {
+      "description": "Date and time when the conversion was created.",
+      "disable_correlation": true,
+      "misp-attribute": "datetime",
+      "ui-priority": 1
+    },
+    "deleted_at": {
+      "description": "Date and time when the conversion was deleted, if it has been moved to trash or removed.",
+      "disable_correlation": true,
+      "misp-attribute": "datetime",
+      "ui-priority": 0
+    },
+    "description": {
+      "description": "Description or analyst notes for the conversion.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "detail_url": {
+      "description": "URL linking to the conversion detail page.",
+      "misp-attribute": "link",
+      "ui-priority": 1
+    },
+    "input_text": {
+      "description": "Input CTI content submitted for conversion, typically MISP JSON or a STIX bundle.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "sane_default": [
+        "MISP JSON input",
+        "STIX JSON input"
+      ],
+      "ui-priority": 1
+    },
+    "is_active": {
+      "description": "Boolean flag indicating whether the conversion is active and not in trash.",
+      "disable_correlation": true,
+      "misp-attribute": "boolean",
+      "sane_default": [
+        "true"
+      ],
+      "ui-priority": 1
+    },
+    "name": {
+      "description": "Title or name of the conversion.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "output_text": {
+      "description": "Output CTI content produced by the conversion, typically a STIX bundle or MISP JSON.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "sane_default": [
+        "STIX JSON output",
+        "MISP JSON output"
+      ],
+      "ui-priority": 1
+    },
+    "output_type": {
+      "description": "Expected output CTI format produced by the conversion.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "sane_default": [
+        "STIX",
+        "MISP"
+      ],
+      "ui-priority": 1,
+      "values_list": [
+        "STIX",
+        "MISP"
+      ]
+    },
+    "public": {
+      "description": "Visibility flag indicating whether the conversion is public.",
+      "disable_correlation": true,
+      "misp-attribute": "boolean",
+      "sane_default": [
+        "false"
+      ],
+      "ui-priority": 1
+    },
+    "updated_at": {
+      "description": "Date and time when the conversion was last updated.",
+      "disable_correlation": true,
+      "misp-attribute": "datetime",
+      "ui-priority": 1
+    },
+    "user_id": {
+      "description": "Identifier of the user or author who performed or owns the CTI Transmute conversion.",
+      "disable_correlation": true,
+      "misp-attribute": "integer",
+      "ui-priority": 1
+    },
+    "uuid": {
+      "description": "UUID of the conversion record.",
+      "misp-attribute": "uuid",
+      "ui-priority": 1
+    }
+  },
+  "description": "CTI Transmute conversion record describing MISP to STIX or STIX to MISP conversion metadata, inputs, outputs, status, and detail link.",
+  "meta-category": "misc",
+  "name": "cti-transmute-conversion",
+  "required": [
+    "name",
+    "input_text",
+    "conversion_type",
+    "output_text"
+  ],
+  "uuid": "feb1cf21-a557-454d-89ed-4716afa183aa",
+  "version": 1
+}


### PR DESCRIPTION
### Motivation
- Provide a MISP object to record CTI conversions performed by CTI Transmute, mapping the requested database fields into MISP object attributes for interoperability and traceability. 
- Ensure reasonable defaults and constrained values for conversion direction and output format to make the object user-friendly and less error-prone.

### Description
- Add a new object template `objects/cti-transmute-conversion/definition.json` that models the conversion record and includes `name`, `description`, `input_text`, `conversion_type`, `output_text`, `created_at`, `updated_at`, `public`, `uuid`, `is_active`, `deleted_at`, and `detail_url` attributes. 
- Map database fields to appropriate MISP attribute types (e.g. `integer` for `user_id`, `text` for `name`/`description`/`input_text`/`output_text`, `datetime` for timestamps, `boolean` for `public`/`is_active`, `uuid` for `uuid`, and `link` for `detail_url`).
- Add `sane_default` values and `values_list` constraints for `conversion_type` (`MISP_TO_STIX`, `STIX_TO_MISP`) and `output_type` (`STIX`, `MISP`), plus sensible defaults for `input_text` and `output_text` placeholders, and include `required` fields `name`, `input_text`, `conversion_type`, and `output_text`.
- Register the new object in `README.md` object listing and set object `version` and generated `uuid` in the template metadata.

### Testing
- Ran `jq . objects/cti-transmute-conversion/definition.json >/dev/null` and `jsonschema -i objects/cti-transmute-conversion/definition.json schema_objects.json` which validated the new template against the repository schema and succeeded. 
- Executed repository validation scripts `./unique_uuid.py` and `./validate_all.sh` (which runs `./jq_all_the_things.sh` and schema checks for all objects) and all checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18490156e48324a883fd6c22ce6d2c)