### PR TITLE
Add INTREP intelligence reporting templates

### DIFF
--- a/objects/intelligence-dissemination/definition.json
+++ b/objects/intelligence-dissemination/definition.json
@@ -1,0 +1,157 @@
+{
+  "attributes": {
+    "acknowledgement-required": {
+      "description": "Whether the recipient must acknowledge receipt.",
+      "disable_correlation": true,
+      "misp-attribute": "boolean",
+      "ui-priority": 0
+    },
+    "acknowledgement-time": {
+      "description": "Date-time group (DTG) or timestamp when receipt was acknowledged.",
+      "disable_correlation": true,
+      "misp-attribute": "datetime",
+      "ui-priority": 0
+    },
+    "classification": {
+      "description": "Classification, marking or traffic-light protocol applied to the disseminated information.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 1,
+      "values_list": [
+        "UNCLASSIFIED",
+        "CONFIDENTIAL",
+        "SECRET",
+        "TOP SECRET",
+        "NATO RESTRICTED",
+        "NATO CONFIDENTIAL",
+        "NATO SECRET",
+        "TLP:CLEAR",
+        "TLP:GREEN",
+        "TLP:AMBER",
+        "TLP:AMBER+STRICT",
+        "TLP:RED"
+      ]
+    },
+    "comment": {
+      "description": "Additional analyst or operator comments.",
+      "disable_correlation": true,
+      "misp-attribute": "comment",
+      "multiple": true,
+      "ui-priority": 0
+    },
+    "dissemination-id": {
+      "description": "Local, organizational or message identifier for this dissemination action.",
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "dissemination-time": {
+      "description": "Date-time group (DTG) or timestamp when the information was disseminated.",
+      "disable_correlation": true,
+      "misp-attribute": "datetime",
+      "ui-priority": 1
+    },
+    "follow-up-action": {
+      "description": "Requested recipient action, follow-up tasking or next step.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "multiple": true,
+      "ui-priority": 0
+    },
+    "handling-instructions": {
+      "description": "Caveats, releasability, dissemination restrictions or handling instructions.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "multiple": true,
+      "ui-priority": 1
+    },
+    "information-copy": {
+      "description": "Information-copy addressee or secondary recipient.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "multiple": true,
+      "ui-priority": 0
+    },
+    "method": {
+      "description": "Dissemination method or channel.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 1,
+      "values_list": [
+        "message",
+        "voice",
+        "email",
+        "chat",
+        "web portal",
+        "API",
+        "briefing",
+        "document",
+        "radio",
+        "courier",
+        "other"
+      ]
+    },
+    "originator": {
+      "description": "Unit, organization, staff section or system that originated the dissemination.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "precedence": {
+      "description": "Message precedence assigned for transmission or dissemination.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 1,
+      "values_list": [
+        "ROUTINE",
+        "PRIORITY",
+        "IMMEDIATE",
+        "FLASH",
+        "FLASH OVERRIDE"
+      ]
+    },
+    "raw-dissemination": {
+      "description": "Original disseminated message, cover note, distribution record or supporting file.",
+      "disable_correlation": true,
+      "misp-attribute": "attachment",
+      "multiple": true,
+      "ui-priority": 0
+    },
+    "recipient": {
+      "description": "Unit, organization, staff section, system, distribution list or individual recipient.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "multiple": true,
+      "ui-priority": 1
+    },
+    "reference": {
+      "description": "Doctrine, SOP, message, URL or external reference supporting the dissemination.",
+      "disable_correlation": true,
+      "misp-attribute": "link",
+      "multiple": true,
+      "ui-priority": 0
+    },
+    "related-report": {
+      "description": "Related INTREP, intelligence report, message or MISP event/object identifier.",
+      "misp-attribute": "text",
+      "multiple": true,
+      "ui-priority": 1
+    },
+    "release-authority": {
+      "description": "Authority, owner or approver authorizing dissemination or release.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 0
+    }
+  },
+  "description": "Object template to document dissemination, distribution, precedence, acknowledgments and follow-up handling for INTREP and similar intelligence reporting.",
+  "meta-category": "misc",
+  "name": "intelligence-dissemination",
+  "requiredOneOf": [
+    "dissemination-id",
+    "related-report",
+    "recipient",
+    "dissemination-time"
+  ],
+  "uuid": "fca90ca9-b3a9-52c2-972f-6617b75665f6",
+  "version": 1
+}

--- a/objects/intelligence-report/definition.json
+++ b/objects/intelligence-report/definition.json
@@ -1,0 +1,214 @@
+{
+  "attributes": {
+    "activity-time": {
+      "description": "Date-time group (DTG) or timestamp of the observed activity.",
+      "disable_correlation": true,
+      "misp-attribute": "datetime",
+      "ui-priority": 1
+    },
+    "authentication": {
+      "description": "Report authentication, release authority or validating official.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 0
+    },
+    "classification": {
+      "description": "Classification, marking or traffic-light protocol applied to the report.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 1,
+      "values_list": [
+        "UNCLASSIFIED",
+        "CONFIDENTIAL",
+        "SECRET",
+        "TOP SECRET",
+        "NATO RESTRICTED",
+        "NATO CONFIDENTIAL",
+        "NATO SECRET",
+        "TLP:CLEAR",
+        "TLP:GREEN",
+        "TLP:AMBER",
+        "TLP:AMBER+STRICT",
+        "TLP:RED"
+      ]
+    },
+    "comment": {
+      "description": "Additional analyst or operator comments.",
+      "disable_correlation": true,
+      "misp-attribute": "comment",
+      "multiple": true,
+      "ui-priority": 0
+    },
+    "conclusion": {
+      "description": "Reporter analysis of what the reported information means.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "date-time": {
+      "description": "Date-time group (DTG) or timestamp when the report was made.",
+      "disable_correlation": true,
+      "misp-attribute": "datetime",
+      "ui-priority": 1
+    },
+    "disseminated-to": {
+      "description": "Unit, organization, staff section or distribution list that received the report.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "multiple": true,
+      "ui-priority": 0
+    },
+    "dissemination-time": {
+      "description": "Date-time group (DTG) or timestamp when the report was disseminated.",
+      "disable_correlation": true,
+      "misp-attribute": "datetime",
+      "ui-priority": 0
+    },
+    "enemy-activity": {
+      "description": "Enemy activity description, including direction and speed if moving.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "enemy-equipment": {
+      "description": "Major enemy equipment observed or assessed.",
+      "misp-attribute": "text",
+      "multiple": true,
+      "ui-priority": 1
+    },
+    "enemy-location": {
+      "description": "Enemy location such as UTM, MGRS grid, coordinate, place or area.",
+      "misp-attribute": "target-location",
+      "multiple": true,
+      "ui-priority": 1
+    },
+    "enemy-size": {
+      "description": "Enemy strength, size or number observed or assessed.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "enemy-unit": {
+      "description": "Enemy nationality, unit designator, name or type.",
+      "misp-attribute": "text",
+      "multiple": true,
+      "ui-priority": 1
+    },
+    "evaluation": {
+      "description": "Evaluation of source, information, BDA or confidence.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "format-reference": {
+      "description": "Doctrine, STANAG, SOP or other format reference used to produce the report.",
+      "disable_correlation": true,
+      "misp-attribute": "link",
+      "multiple": true,
+      "ui-priority": 0
+    },
+    "handling-instructions": {
+      "description": "Caveats, releasability or handling instructions for the report.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "multiple": true,
+      "ui-priority": 1
+    },
+    "narrative": {
+      "description": "Free text for additional information required for clarification of the report.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "precedence": {
+      "description": "Message precedence assigned for transmission or dissemination.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 0,
+      "values_list": [
+        "ROUTINE",
+        "PRIORITY",
+        "IMMEDIATE",
+        "FLASH",
+        "FLASH OVERRIDE"
+      ]
+    },
+    "raw-report": {
+      "description": "Original INTREP message, form, attachment or supporting file.",
+      "disable_correlation": true,
+      "misp-attribute": "attachment",
+      "multiple": true,
+      "ui-priority": 0
+    },
+    "related-report": {
+      "description": "Related message, report or MISP event/object identifier.",
+      "misp-attribute": "text",
+      "multiple": true,
+      "ui-priority": 0
+    },
+    "related-requirement": {
+      "description": "Related PIR, IR, RFI, tasking or collection requirement identifier.",
+      "misp-attribute": "text",
+      "multiple": true,
+      "ui-priority": 0
+    },
+    "report-id": {
+      "description": "Local, organizational or message identifier for the INTREP.",
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "report-number": {
+      "description": "Report format number, for example I001 or 1001 for INTREP.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 1,
+      "values_list": [
+        "I001",
+        "1001"
+      ]
+    },
+    "report-type": {
+      "description": "Report or message type name.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 1,
+      "values_list": [
+        "INTREP",
+        "Intelligence Report"
+      ]
+    },
+    "reporting-unit": {
+      "description": "Unit, organization or collector element making the report.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "sources": {
+      "description": "Reliability rating of source and credibility rating of information, or a source summary.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "multiple": true,
+      "ui-priority": 1
+    },
+    "usmtf-message-id": {
+      "description": "USMTF message identifier, for example C110 for INTREP.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 1,
+      "values_list": [
+        "C110"
+      ]
+    }
+  },
+  "description": "Object template for an Intelligence Report (INTREP) based on FM 34-35, FM 101-5-2 and FM 6-99 report/message formats for tactical intelligence reporting and dissemination.",
+  "meta-category": "misc",
+  "name": "intelligence-report",
+  "requiredOneOf": [
+    "report-id",
+    "date-time",
+    "narrative",
+    "raw-report"
+  ],
+  "uuid": "a88289fe-9afb-54b7-97a6-f51c6a004942",
+  "version": 1
+}

--- a/objects/intelligence-source-assessment/definition.json
+++ b/objects/intelligence-source-assessment/definition.json
@@ -1,0 +1,137 @@
+{
+  "attributes": {
+    "collection-method": {
+      "description": "Collection method, interview, sensor, liaison, exploitation or observation method used.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "multiple": true,
+      "ui-priority": 0
+    },
+    "collection-time": {
+      "description": "Date-time group (DTG) or timestamp when information was collected.",
+      "disable_correlation": true,
+      "misp-attribute": "datetime",
+      "ui-priority": 0
+    },
+    "collector-unit": {
+      "description": "Unit, organization or collector element that collected or reported the information.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 0
+    },
+    "comment": {
+      "description": "Additional analyst or operator comments.",
+      "disable_correlation": true,
+      "misp-attribute": "comment",
+      "multiple": true,
+      "ui-priority": 0
+    },
+    "confidence": {
+      "description": "Analytic confidence or certainty assigned to the assessed information.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 1,
+      "values_list": [
+        "low",
+        "medium",
+        "high",
+        "unknown"
+      ]
+    },
+    "evaluation": {
+      "description": "Evaluation of source, information, BDA, bias, access, timeliness or corroboration.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "information-credibility": {
+      "description": "Information credibility rating, including Admiralty/NATO-style 1-6 ratings where applicable.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 1,
+      "values_list": [
+        "1 - Confirmed by other sources",
+        "2 - Probably true",
+        "3 - Possibly true",
+        "4 - Doubtfully true",
+        "5 - Improbable",
+        "6 - Truth cannot be judged"
+      ]
+    },
+    "raw-assessment": {
+      "description": "Original source evaluation, collector note, grading record or supporting file.",
+      "disable_correlation": true,
+      "misp-attribute": "attachment",
+      "multiple": true,
+      "ui-priority": 0
+    },
+    "related-report": {
+      "description": "Related INTREP, intelligence report, message or MISP event/object identifier.",
+      "misp-attribute": "text",
+      "multiple": true,
+      "ui-priority": 0
+    },
+    "related-requirement": {
+      "description": "Related PIR, IR, RFI, tasking or collection requirement identifier.",
+      "misp-attribute": "text",
+      "multiple": true,
+      "ui-priority": 0
+    },
+    "source-id": {
+      "description": "Identifier, code name or local reference for the source, collector or reporting channel.",
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "source-reliability": {
+      "description": "Source reliability rating, including Admiralty/NATO-style A-F ratings where applicable.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 1,
+      "values_list": [
+        "A - Completely reliable",
+        "B - Usually reliable",
+        "C - Fairly reliable",
+        "D - Not usually reliable",
+        "E - Unreliable",
+        "F - Reliability cannot be judged"
+      ]
+    },
+    "source-summary": {
+      "description": "Non-sensitive summary of the source, access, placement or reporting channel.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "source-type": {
+      "description": "Type of source or collection discipline.",
+      "disable_correlation": true,
+      "misp-attribute": "text",
+      "ui-priority": 1,
+      "values_list": [
+        "HUMINT",
+        "CI",
+        "SIGINT",
+        "ELINT",
+        "IMINT",
+        "OSINT",
+        "MASINT",
+        "TECHINT",
+        "FININT",
+        "SOCMINT",
+        "All-source",
+        "Other"
+      ]
+    }
+  },
+  "description": "Object template to capture source reliability, information credibility and evaluation details supporting an INTREP or similar intelligence report.",
+  "meta-category": "misc",
+  "name": "intelligence-source-assessment",
+  "requiredOneOf": [
+    "source-id",
+    "source-summary",
+    "information-credibility",
+    "raw-assessment"
+  ],
+  "uuid": "2d3a5895-6c54-50b5-bd25-ce33e974c50a",
+  "version": 1
+}


### PR DESCRIPTION
### Motivation
- Provide MISP object templates to encode tactical intelligence reports (INTREP) and their supporting metadata following FM 34-35 / FM 101-5-2 / FM 6-99 style formats to improve structured reporting and dissemination.
- Capture source assessment and dissemination records so reports, source reliability/credibility, and distribution/handling information can be recorded and exchanged reliably.

### Description
- Add `intelligence-report` object template (`objects/intelligence-report/definition.json`) to record DTG/report identifiers, reporting unit, classification/handling, enemy SALUTE-style fields (size, activity, location, unit, equipment, activity time), sources/evaluation, narrative, related requirements/reports, and raw report attachments.
- Add `intelligence-source-assessment` object template (`objects/intelligence-source-assessment/definition.json`) to model source identifiers, collection method/time, source discipline, Admiralty/NATO source reliability (`A-F`) and information credibility (`1-6`) ratings, analytic confidence, evaluation text, related links, and raw assessment attachments.
- Add `intelligence-dissemination` object template (`objects/intelligence-dissemination/definition.json`) to record dissemination actions including originator, recipients, method/channel, precedence, classification/handling, release authority, acknowledgement requirements/timestamps, follow-up actions, references, and raw dissemination records.
- All templates use `meta-category: misc`, include `requiredOneOf` minimal presence constraints, and include UI-friendly `values_list`/`misp-attribute` mappings for common fields.

### Testing
- Validated each new object against the repository schema with `jsonschema.validate(...)` (Python `jsonschema`) and each file reported `ok` during validation. 
- Ran repository-wide formatting/consistency tooling via `./jq_all_the_things.sh` and `./validate_all.sh` (using temporary `jsonschema`/`uuidparse` wrappers when CLI helpers were not present), and the validation completed successfully. 
- Ran `unique_uuid.py` to ensure generated UUIDs were unique and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c9f391d808324aada2a6130ba3c2f)