### PR TITLE
chg: add reciprocal ownership and manufacturing relationships

### DIFF
--- a/relationships/definition.json
+++ b/relationships/definition.json
@@ -712,9 +712,11 @@
     {
       "description": "This relationship describes an object which is an operator of another object.",
       "format": [
-        "cert-eu"
+        "cert-eu",
+        "misp"
       ],
-      "name": "operator-of"
+      "name": "operator-of",
+      "opposite": "operated-by"
     },
     {
       "description": "This relationship describes an object which overlaps another object.",
@@ -727,9 +729,11 @@
       "description": "This relationship describes an object which owns another object.",
       "format": [
         "cert-eu",
-        "alfred"
+        "alfred",
+        "misp"
       ],
-      "name": "owner-of"
+      "name": "owner-of",
+      "opposite": "owned-by"
     },
     {
       "description": "This relationship describes an object which publishes method for another object.",
@@ -785,7 +789,8 @@
       "format": [
         "misp"
       ],
-      "name": "controls"
+      "name": "controls",
+      "opposite": "controlled-by"
     },
     {
       "description": "This relationships describes an object which annotates another object.",
@@ -2373,7 +2378,47 @@
       ],
       "name": "inspects",
       "opposite": "inspected-by"
+    },
+    {
+      "description": "This relationship describes an object which is operated by another object.",
+      "format": [
+        "misp"
+      ],
+      "name": "operated-by",
+      "opposite": "operator-of"
+    },
+    {
+      "description": "This relationship describes an object which is owned by another object.",
+      "format": [
+        "misp"
+      ],
+      "name": "owned-by",
+      "opposite": "owner-of"
+    },
+    {
+      "description": "This relationship describes an object which is controlled by another object.",
+      "format": [
+        "misp"
+      ],
+      "name": "controlled-by",
+      "opposite": "controls"
+    },
+    {
+      "description": "This relationship describes an object which manufactures another object.",
+      "format": [
+        "misp"
+      ],
+      "name": "manufactures",
+      "opposite": "manufactured-by"
+    },
+    {
+      "description": "This relationship describes an object which is manufactured by another object.",
+      "format": [
+        "misp"
+      ],
+      "name": "manufactured-by",
+      "opposite": "manufactures"
     }
   ],
-  "version": 52
+  "version": 53
 }


### PR DESCRIPTION
### Motivation
- The UAV-related model lacked reciprocal ownership/operator/controller relationships and a link to manufacturers which impedes bidirectional traversal and consistent MISP usage.
- Make existing `operator-of`/`owner-of`/`controls` usable in MISP by declaring the `misp` format and adding missing opposites.
- Version bump is required after adding new relationship entries to keep the definitions consistent.

### Description
- Updated `relationships/definition.json` to add opposites for `operator-of` (`operated-by`), `owner-of` (`owned-by`), and `controls` (`controlled-by`) and added `misp` to the existing entries' `format` lists.
- Added the new inverse relationship definitions: `operated-by`, `owned-by`, `controlled-by`, plus `manufactures` and `manufactured-by` to model manufacturers and their products.
- Incremented the relationships file version from `52` to `53` and committed the change as `1fa5676` with message `chg: [relationships] add UAV ownership relationships`.

### Testing
- Ran `python -m json.tool relationships/definition.json` which succeeded and validated JSON syntax.
- Ran `./tools/validate_opposites.sh` and a custom Python check for unique names and reciprocal `opposite` fields, both succeeded.
- Ran `git diff --check` and ensured there were no diff/whitespace issues after the commit.
- Full JSON Schema CLI validation (`jsonschema -i relationships/definition.json schema_relationships.json`) was not run because the `jsonschema` CLI is not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a788f8302cc8325b29b603465fd20a7)