### PR TITLE
Add threat-hunt-* object set for structured threat hunt sharing

### DIFF
--- a/objects/threat-hunt-context/definition.json
+++ b/objects/threat-hunt-context/definition.json
@@ -1,0 +1,96 @@
+{
+  "name": "threat-hunt-context",
+  "description": "Metadata describing the purpose, methodology, and resourcing of a threat hunt. One instance per MISP event; corresponds to the Purpose and Equip sections of the hunt report.",
+  "meta-category": "threat-hunting",
+  "uuid": "6dec94ff-b74b-4cab-ad38-3d3c8308bdb3",
+  "version": 1,
+  "attributes": {
+    "hunt-title": {
+      "description": "Title of the hunt.",
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "purpose": {
+      "description": "Why the hunt is being conducted: the trigger, driving intelligence, or business question (Purpose section).",
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "methodology": {
+      "description": "Hunt methodology, per the PEAK framework. Mirror on the event as a hunt:methodology tag.",
+      "misp-attribute": "text",
+      "disable_correlation": true,
+      "sane_default": [
+        "structured-hypothesis-driven",
+        "unstructured-baseline",
+        "situational-ioc-driven",
+        "model-assisted"
+      ],
+      "ui-priority": 0
+    },
+    "status": {
+      "description": "Lifecycle state of the hunt. Mirror on the event as a workflow:state tag.",
+      "misp-attribute": "text",
+      "disable_correlation": true,
+      "sane_default": [
+        "Planned",
+        "In Progress",
+        "Concluded",
+        "Recurring"
+      ],
+      "ui-priority": 0
+    },
+    "period-start": {
+      "description": "Start of the data window examined by the hunt.",
+      "misp-attribute": "datetime",
+      "disable_correlation": true,
+      "ui-priority": 0
+    },
+    "period-end": {
+      "description": "End of the data window examined by the hunt.",
+      "misp-attribute": "datetime",
+      "disable_correlation": true,
+      "ui-priority": 0
+    },
+    "data-source": {
+      "description": "Data source examined during the hunt (Equip > Data Sources Examined).",
+      "misp-attribute": "text",
+      "multiple": true,
+      "disable_correlation": true,
+      "sane_default": [
+        "Network Logs",
+        "Sysmon Logs",
+        "Event Logs",
+        "EDR Telemetry",
+        "Cloud Audit Logs",
+        "DNS Logs",
+        "Proxy Logs"
+      ],
+      "ui-priority": 0
+    },
+    "tool": {
+      "description": "Tooling or platform used to execute the hunt (Equip > Tools Utilized).",
+      "misp-attribute": "text",
+      "multiple": true,
+      "disable_correlation": true,
+      "sane_default": [
+        "Splunk",
+        "Microsoft Sentinel",
+        "Elastic",
+        "CrowdStrike",
+        "Chronicle"
+      ],
+      "ui-priority": 0
+    },
+    "contributor": {
+      "description": "Person, team, or organisation that contributed to the hunt (Equip > Contributors).",
+      "misp-attribute": "text",
+      "multiple": true,
+      "disable_correlation": true,
+      "ui-priority": 0
+    }
+  },
+  "required": [
+    "hunt-title",
+    "purpose"
+  ]
+}

--- a/objects/threat-hunt-finding/definition.json
+++ b/objects/threat-hunt-finding/definition.json
@@ -1,0 +1,48 @@
+{
+  "name": "threat-hunt-finding",
+  "description": "The outcome of testing a hypothesis: conclusion, classification, and follow-up. Corresponds to the Feedback section of a hunt report. One instance per hypothesis.",
+  "meta-category": "threat-hunting",
+  "uuid": "ce3ab17c-9ac5-47fb-bad5-48d368568437",
+  "version": 1,
+  "attributes": {
+    "hypothesis-id": {
+      "description": "Local hypothesis-id this finding concludes, e.g. H1. Also link formally via an Object Reference of type 'resulted-in' from the threat-hunt-hypothesis object.",
+      "misp-attribute": "text",
+      "disable_correlation": true,
+      "ui-priority": 1
+    },
+    "outcome": {
+      "description": "Classification of the finding. Mirror as a hunt:outcome tag on this object for tag-based dashboards.",
+      "misp-attribute": "text",
+      "disable_correlation": true,
+      "sane_default": [
+        "True Positive",
+        "Benign True Positive",
+        "False Positive",
+        "Inconclusive",
+        "Detection Gap Identified"
+      ],
+      "ui-priority": 1
+    },
+    "conclusion": {
+      "description": "Summary of what was found and how it was confirmed or ruled out.",
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "recommendation": {
+      "description": "Suggested follow-up action, in free text. For structured, trackable remediation, link a course-of-action object instead via an Object Reference of type 'mitigated-by'.",
+      "misp-attribute": "text",
+      "ui-priority": 0
+    },
+    "detection-gap": {
+      "description": "True if the hunt revealed a missing, broken, or under-tuned detection that should be engineered.",
+      "misp-attribute": "boolean",
+      "disable_correlation": true,
+      "ui-priority": 0
+    }
+  },
+  "required": [
+    "outcome",
+    "conclusion"
+  ]
+}

--- a/objects/threat-hunt-hypothesis/definition.json
+++ b/objects/threat-hunt-hypothesis/definition.json
@@ -1,0 +1,63 @@
+{
+  "name": "threat-hunt-hypothesis",
+  "description": "A single testable hypothesis from the Scope and Execute sections of a hunt: its scoping decision, targeted ATT&CK technique(s), and analytic reasoning. One instance per hypothesis.",
+  "meta-category": "threat-hunting",
+  "uuid": "4136cd18-3edd-49fb-90ba-24cbacacc662",
+  "version": 1,
+  "attributes": {
+    "hypothesis-id": {
+      "description": "Short local identifier (e.g. H1) used to cross-reference this hypothesis from threat-hunt-query and threat-hunt-finding objects within the same event.",
+      "misp-attribute": "text",
+      "disable_correlation": true,
+      "ui-priority": 1
+    },
+    "hypothesis": {
+      "description": "The hypothesis statement.",
+      "misp-attribute": "text",
+      "ui-priority": 1
+    },
+    "scope": {
+      "description": "Whether this hypothesis was included or excluded from the hunt (Scope section).",
+      "misp-attribute": "text",
+      "disable_correlation": true,
+      "sane_default": [
+        "In-Scope",
+        "Out-of-Scope"
+      ],
+      "ui-priority": 0
+    },
+    "rationale": {
+      "description": "Why the hypothesis was included or excluded from scope.",
+      "misp-attribute": "text",
+      "ui-priority": 0
+    },
+    "attack-id": {
+      "description": "MITRE ATT&CK technique/sub-technique ID(s) this hypothesis targets, e.g. T1110.003. Pair with a mitre-attack-pattern galaxy tag on this object for machine-readable correlation.",
+      "misp-attribute": "text",
+      "multiple": true,
+      "disable_correlation": true,
+      "ui-priority": 1
+    },
+    "analysis": {
+      "description": "Analytic reasoning applied when testing the hypothesis: thought process, pivoting logic, baseline used (Execute > Analysis).",
+      "misp-attribute": "text",
+      "ui-priority": 0
+    },
+    "status": {
+      "description": "Execution status of this hypothesis.",
+      "misp-attribute": "text",
+      "disable_correlation": true,
+      "sane_default": [
+        "Not Started",
+        "In Progress",
+        "Tested",
+        "Deferred"
+      ],
+      "ui-priority": 0
+    }
+  },
+  "required": [
+    "hypothesis",
+    "scope"
+  ]
+}

--- a/objects/threat-hunt-query/definition.json
+++ b/objects/threat-hunt-query/definition.json
@@ -1,0 +1,66 @@
+{
+  "name": "threat-hunt-query",
+  "description": "A platform-native hunting query used to test a hypothesis. Use this object for SPL, KQL, EQL, and similar query languages. When the detection logic is portable, prefer the standard MISP sigma or yara object instead and link it to the hypothesis with a 'tests' Object Reference.",
+  "meta-category": "threat-hunting",
+  "uuid": "0fc943ec-c8fd-4311-b748-249bdef0f7d8",
+  "version": 1,
+  "attributes": {
+    "hypothesis-id": {
+      "description": "Local hypothesis-id this query tests, e.g. H1. Also link formally via an Object Reference of type 'tests' to the threat-hunt-hypothesis object.",
+      "misp-attribute": "text",
+      "disable_correlation": true,
+      "ui-priority": 1
+    },
+    "query-language": {
+      "description": "Language/dialect of the query.",
+      "misp-attribute": "text",
+      "disable_correlation": true,
+      "sane_default": [
+        "SPL",
+        "KQL",
+        "EQL",
+        "OSQuery SQL",
+        "YARA-L",
+        "STIX Pattern",
+        "Other"
+      ],
+      "ui-priority": 1
+    },
+    "query": {
+      "description": "The literal query or search.",
+      "misp-attribute": "text",
+      "disable_correlation": true,
+      "ui-priority": 1
+    },
+    "data-source": {
+      "description": "Index, sourcetype, or table the query runs against.",
+      "misp-attribute": "text",
+      "multiple": true,
+      "disable_correlation": true,
+      "ui-priority": 0
+    },
+    "platform": {
+      "description": "Platform the query is written for.",
+      "misp-attribute": "text",
+      "disable_correlation": true,
+      "sane_default": [
+        "Splunk",
+        "Microsoft Sentinel",
+        "Elastic",
+        "CrowdStrike",
+        "Chronicle",
+        "osquery"
+      ],
+      "ui-priority": 0
+    },
+    "comment": {
+      "description": "Notes on tuning, thresholds, or known exclusions.",
+      "misp-attribute": "comment",
+      "ui-priority": 0
+    }
+  },
+  "required": [
+    "query",
+    "query-language"
+  ]
+}


### PR DESCRIPTION
**Why**
MISP has hundreds of object templates but nothing for the narrative arc of a hunt itself. You can express an indicator, a Sigma rule, or a course of action, but there's no object for "here's a hypothesis I tested" or "here's what I found and why it matters." Without one, a shared hunt either gets flattened into raw IOC attributes (the reasoning behind them lost) or written up as a free-text Event Report (structure and queryability both lost). These four objects fill that gap.

**Companion taxonomy**
Paired with the HUNT-EX taxonomy proposed in [MISP/misp-taxonomies#345](https://github.com/MISP/misp-taxonomies/pull/342). HUNT-EX answers "can I run this, should I care, did anyone find anything, what happens next" from the tag list. These objects are what you get when you open the event.